### PR TITLE
DFC-85/DFC-92: add navigation tracker

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -7,7 +7,6 @@
 <div align="center">
   
 <h3 align="center">GOV UK One Login GA4 Implementation</h3>
-
   <p align="center">
     This package enables GOV UK LOGIN frontend Node.js applications to use Google Tag Manager and Google Analytics 4.
     <br />
@@ -42,7 +41,11 @@
 
 ## About The Project
 
-This package enables GOV UK LOGIN frontend Node.js applications to use Google Tag Manager and Google Analytics 4.
+The GDS One Login GA4 (Google Analytics 4) node package is a shared, reusable solution created to facilitate the upgrade from GAU to GA4 across the One Login programme as GAU is being retired mid 2024.
+
+The purpose of this package is to make it as easy as possible for the various pods that make up the One Login journey to upgrade their analytics while having as minimal an impact as possible on the dev teams time and effort.
+
+The package is owned by the DI Frontend Capability team, part of the development of this tool involves ongoing discovery with the pods responsible for maintaining the frontend repositories that make up the One Login journey. As more information is collated, the package and documentation will be updated. As such, it is considered a WIP and the pods will be notified when a stable release is ready.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -102,5 +105,17 @@ window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
   taxonomy_level2: "test tax2",
 });
 ```
+
+### Navigation Tracker
+
+Navigation tracking allows us to see exactly how often each navigation link is used. It's triggered by a listener on the click event.
+
+We are tracking different types of link:
+
+- Generic Inbound Links: When a user clicks on a link and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- Generic Inbound Button: When a user clicks on a button and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- Generic Outbound Links: When a user clicks on a link and it is an outbound link, which is defined as any links that point to a domain that does not match the domain of the current page.
+- Header Menu Bar: When a user clicks on a link in the header menu
+- Footer links: When a user clicks on a link within the footer
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-login-ga4",
-  "version": "0.0.19-dev",
+  "version": "0.0.20-dev",
   "description": "Reusable GA4 package for GDS One Login",
   "main": "lib/analytics.js",
   "type": "module",

--- a/src/analytics/baseTracker/baseTracker.ts
+++ b/src/analytics/baseTracker/baseTracker.ts
@@ -1,4 +1,5 @@
 import { PageViewEventInterface } from "../pageViewTracker/pageViewTracker.interface";
+import { NavigationEventInterface } from "../navigationTracker/navigationTracker.interface";
 
 declare global {
   interface Window {
@@ -17,7 +18,9 @@ export class BaseTracker {
    * @param {PageViewEventInterface} event - The event to be pushed to the data layer.
    * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
    */
-  pushToDataLayer(event: PageViewEventInterface): boolean {
+  pushToDataLayer(
+    event: PageViewEventInterface | NavigationEventInterface,
+  ): boolean {
     console.log("running pushToDataLayer");
     window.dataLayer = window.dataLayer || [];
     try {

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -1,8 +1,10 @@
+import { NavigationTracker } from "../navigationTracker/navigationTracker";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
 
 export class Analytics {
   gtmId: string;
   pageViewTracker: PageViewTracker;
+  navigationTracker: NavigationTracker;
 
   /**
    * Initializes a new instance of the class.
@@ -12,6 +14,7 @@ export class Analytics {
   constructor(gtmId: string) {
     this.gtmId = gtmId;
     this.pageViewTracker = new PageViewTracker();
+    this.navigationTracker = new NavigationTracker();
     this.loadGtmScript();
   }
 

--- a/src/analytics/navigationTracker/navigationTracker.interface.ts
+++ b/src/analytics/navigationTracker/navigationTracker.interface.ts
@@ -1,0 +1,12 @@
+export interface NavigationEventInterface {
+  event: string;
+  event_data: {
+    event_name: string;
+    type: string;
+    url: string;
+    text: string;
+    section: string;
+    action: string;
+    external: string;
+  };
+}

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import { NavigationTracker } from "./navigationTracker";
-import { NavigationEventInterface } from "./navigationTracker.interface";
 
-describe("pageViewTracker", () => {
+describe("navigationTracker", () => {
   const newInstance = new NavigationTracker();
   const action = new MouseEvent("click", {
     view: window,

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { NavigationTracker } from "./navigationTracker";
+import { NavigationEventInterface } from "./navigationTracker.interface";
+
+describe("pageViewTracker", () => {
+  const newInstance = new NavigationTracker();
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+  const spy = jest.spyOn(NavigationTracker.prototype, "pushToDataLayer");
+  const constructorSpy = jest.spyOn(
+    NavigationTracker.prototype,
+    "initialiseEventListener",
+  );
+
+  test("new instance should call initialiseEventListener", () => {
+    const instance = new NavigationTracker();
+    expect(newInstance.initialiseEventListener).toBeCalled();
+  });
+
+  //test trackNavigation doesn't accept anything except button or link
+  test("trackNavigation should return false if not a link or a button", () => {
+    const href = document.createElement("div");
+    href.className = "govuk-footer__link";
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+
+  //test trackNavigation accept button
+  test("trackNavigation should return true if a link", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.innerHTML = "Link to GOV.UK";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(true);
+    });
+    href.dispatchEvent(action);
+  });
+
+  //test trackNavigation accept link
+  test("trackNavigation should return true if a button", () => {
+    const href = document.createElement("BUTTON");
+    href.className = "govuk-footer__link";
+    href.innerHTML = "Link to GOV.UK";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(true);
+    });
+    href.dispatchEvent(action);
+  });
+
+  //test pushToDataLayer is called
+  test("pushToDataLayer is called", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.addEventListener("click", (event) => {
+      newInstance.trackNavigation(event);
+    });
+    href.dispatchEvent(action);
+    expect(newInstance.pushToDataLayer).toBeCalled();
+  });
+});
+
+describe("getLinkType", () => {
+  const newInstance = new NavigationTracker();
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test('should return "footer" when the element is an <a> tag with footer link class', () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getLinkType(element)).toBe("footer");
+  });
+
+  test('should return "header menu bar" when the element is an <a> tag with header menu bar link class', () => {
+    const href = document.createElement("A");
+    href.className = "header__navigation";
+    href.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getLinkType(element)).toBe("header menu bar");
+  });
+
+  test('should return "generic link" when the element is an <a> tag without footer or header menu bar link class', () => {
+    const href = document.createElement("A");
+    href.className = "other-link";
+    href.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getLinkType(element)).toBe("generic link");
+  });
+
+  test('should return "generic button" when the element is a <button> tag', () => {
+    const button = document.createElement("BUTTON");
+    button.className = "other-link";
+    button.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getLinkType(element)).toBe("generic button");
+  });
+});
+
+describe("isExternalLink", () => {
+  const newInstance = new NavigationTracker();
+
+  test("should return false for internal links", () => {
+    const url = "http://localhost";
+    expect(newInstance.isExternalLink(url)).toBe(false);
+  });
+
+  test("should return true for external links", () => {
+    const url = "https://google.com";
+    expect(newInstance.isExternalLink(url)).toBe(true);
+  });
+});
+
+describe("isHeaderMenuBarLink", () => {
+  const newInstance = new NavigationTracker();
+
+  test('should return true if the class name includes "header__navigation"', () => {
+    expect(newInstance.isHeaderMenuBarLink("header__navigation")).toBe(true);
+  });
+
+  test('should return false if the class name does not include "header__navigation"', () => {
+    expect(newInstance.isHeaderMenuBarLink("header__logo")).toBe(false);
+  });
+
+  test('should return true if the class name includes "header__navigation" along with other classes', () => {
+    expect(
+      newInstance.isHeaderMenuBarLink("header__navigation header__logo"),
+    ).toBe(true);
+  });
+
+  test("should return false if the class name is an empty string", () => {
+    expect(newInstance.isHeaderMenuBarLink("")).toBe(false);
+  });
+});
+
+describe("isFooterLink", () => {
+  const newInstance = new NavigationTracker();
+
+  test("should return true if the class name contains 'govuk-footer__link'", () => {
+    expect(newInstance.isFooterLink("govuk-footer__link")).toBe(true);
+  });
+
+  test("should return false if the class name does not contain 'govuk-footer__link'", () => {
+    expect(newInstance.isFooterLink("some-other-class")).toBe(false);
+  });
+
+  test("should return true if the class name contains 'govuk-footer__link' along with other classes", () => {
+    expect(
+      newInstance.isFooterLink("govuk-footer__link some-other-class"),
+    ).toBe(true);
+  });
+
+  test("should return true if the class name contains 'govuk-footer__link' as a substring", () => {
+    expect(newInstance.isFooterLink("some-class-govuk-footer__link")).toBe(
+      true,
+    );
+  });
+
+  test("should return false if the class name is an empty string", () => {
+    expect(newInstance.isFooterLink("")).toBe(false);
+  });
+});

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -1,0 +1,116 @@
+import { EmbeddedMetadata } from "typeorm/metadata/EmbeddedMetadata";
+import { BaseTracker } from "../baseTracker/baseTracker";
+import { NavigationEventInterface } from "./navigationTracker.interface";
+
+export class NavigationTracker extends BaseTracker {
+  eventName: string = "event_data";
+
+  constructor() {
+    super();
+    this.initialiseEventListener();
+  }
+
+  /**
+   * Initialises the event listener for the document click event.
+   *
+   * @param {type} None
+   * @return {type} None
+   */
+  initialiseEventListener() {
+    document.addEventListener("click", this.trackNavigation.bind(this), false);
+  }
+
+  /**
+   * Tracks the page load event and sends the relevant data to the data layer.
+   *
+   * @param {PageViewParametersInterface} parameters - The parameters for the page view event.
+   * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
+   */
+  trackNavigation(event: Event): boolean {
+    const element: HTMLLinkElement = event.target as HTMLLinkElement;
+    /**
+     * Navigation tracker is only for links and buttons
+     */
+    if (element.tagName !== "A" && element.tagName !== "BUTTON") {
+      return false;
+    }
+
+    const navigationTrackerEvent: NavigationEventInterface = {
+      event: this.eventName,
+      event_data: {
+        event_name: "navigation",
+        type: this.getLinkType(element),
+        url: element.href ? element.href.toLocaleLowerCase() : "undefined",
+        text: element.innerHTML ? element.innerHTML.toLowerCase() : "undefined",
+        section: "undefined",
+        action: "undefined",
+        external: this.isExternalLink(element.href) ? "true" : "false",
+      },
+    };
+
+    try {
+      this.pushToDataLayer(navigationTrackerEvent);
+      return true;
+    } catch (err) {
+      console.error("Error in trackNavigation", err);
+      return false;
+    }
+  }
+
+  /**
+   * Determines if the given URL is an external link.
+   *
+   * @param {string} url - The URL to check.
+   * @return {boolean} Returns true if the URL is an external link, false otherwise.
+   */
+  isExternalLink(url: string): boolean {
+    if (!url) {
+      return false;
+    }
+
+    if (url.includes(window.location.hostname)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns the type of link based on the given HTML link element.
+   *
+   * @param {HTMLLinkElement} element - The HTML link element to get the type of.
+   * @return {string} The type of link: "footer", "header menu bar", "generic link", "generic button", or "undefined".
+   */
+  getLinkType(element: HTMLLinkElement): string {
+    if (element.tagName === "A") {
+      if (this.isFooterLink(element.className)) {
+        return "footer";
+      } else if (this.isHeaderMenuBarLink(element.className)) {
+        return "header menu bar";
+      }
+      return "generic link";
+    } else if (element.tagName === "BUTTON") {
+      return "generic button";
+    }
+    return "undefined"; // generic button
+  }
+
+  /**
+   * Determines whether the given class name is a footer link.
+   *
+   * @param {string} className - The class name to check.
+   * @return {boolean} Returns true if the class name contains "govuk-footer__link", otherwise returns false.
+   */
+  isFooterLink(className: string): boolean {
+    return className.includes("govuk-footer__link");
+  }
+
+  /**
+   * Determines if the given class name is a header menu bar link.
+   *
+   * @param {string} className - The class name to check.
+   * @return {boolean} Returns true if the class name includes "header__navigation", false otherwise.
+   */
+  isHeaderMenuBarLink(className: string): boolean {
+    return className.includes("header__navigation");
+  }
+}

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -1,6 +1,6 @@
-import { EmbeddedMetadata } from "typeorm/metadata/EmbeddedMetadata";
 import { BaseTracker } from "../baseTracker/baseTracker";
 import { NavigationEventInterface } from "./navigationTracker.interface";
+import { validateParameter } from "../../utils/validateParameter";
 
 export class NavigationTracker extends BaseTracker {
   eventName: string = "event_data";
@@ -40,8 +40,10 @@ export class NavigationTracker extends BaseTracker {
       event_data: {
         event_name: "navigation",
         type: this.getLinkType(element),
-        url: element.href ? element.href.toLocaleLowerCase() : "undefined",
-        text: element.innerHTML ? element.innerHTML.toLowerCase() : "undefined",
+        url: element.href ? validateParameter(element.href, 100) : "undefined",
+        text: element.innerHTML
+          ? validateParameter(element.innerHTML, 100)
+          : "undefined",
         section: "undefined",
         action: "undefined",
         external: this.isExternalLink(element.href) ? "true" : "false",

--- a/src/analytics/navigationViewTracker/navigationViewTracker.ts
+++ b/src/analytics/navigationViewTracker/navigationViewTracker.ts
@@ -1,6 +1,0 @@
-function navigationViewTracker() {
-  console.log("running navigationViewTracker");
-  return "";
-}
-
-export default navigationViewTracker;

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -11,7 +11,7 @@ describe("pageViewTracker", () => {
 
   const parameters: PageViewParametersInterface = {
     statusCode: 200,
-    englishPageTitle: "Home",
+    englishPageTitle: "home",
     taxonomy_level1: "taxo1",
     taxonomy_level2: "taxo2",
   };

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -3,7 +3,7 @@ import {
   PageViewParametersInterface,
   PageViewEventInterface,
 } from "./pageViewTracker.interface";
-import validateParameter from "../../utils/validateParameter";
+import { validateParameter } from "../../utils/validateParameter";
 
 export class PageViewTracker extends BaseTracker {
   eventName: string = "page_view_ga4";

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -18,7 +18,6 @@ export class PageViewTracker extends BaseTracker {
    * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
    */
   trackOnPageLoad(parameters: PageViewParametersInterface): boolean {
-    console.log("running trackOnPageLoad");
     const pageViewTrackerEvent: PageViewEventInterface = {
       event: this.eventName,
       page_view: {

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "@jest/globals";
-import validateParameter from "./validateParameter";
+import { validateParameter } from "./validateParameter";
 
 describe("validateParameter", () => {
   test("parameter of type string and allowed length should be returned", () => {
-    const parameter = "Hello world";
+    const parameter = "hello world";
     const validatedParameter = validateParameter(parameter, 100);
     expect(validatedParameter).toEqual(parameter);
   });
@@ -11,7 +11,7 @@ describe("validateParameter", () => {
   test("invalid types should be replaced by an error message", () => {
     const parameter = 1234;
     const validatedParameter = validateParameter(parameter, 100);
-    expect(validatedParameter).toEqual("Invalid type provided");
+    expect(validatedParameter).toEqual("invalid type provided");
   });
 
   test("parameters with invalid lengths should be truncated", () => {
@@ -23,6 +23,6 @@ describe("validateParameter", () => {
   test("empty parameters should be replaced with error message", () => {
     const parameter = "";
     const validatedParameter = validateParameter(parameter, 100);
-    expect(validatedParameter).toEqual("No parameter provided");
+    expect(validatedParameter).toEqual("no parameter provided");
   });
 });

--- a/src/utils/validateParameter.ts
+++ b/src/utils/validateParameter.ts
@@ -2,7 +2,7 @@
  *   Takes a paremeter passed in from external use of a tracker and asserts it is defined, is a string and has a length allowed by GA
  */
 
-export default function validateParameter(parameter: any, maxLength: number) {
+export function validateParameter(parameter: any, maxLength: number) {
   let validatedParameter = parameter || "No parameter provided";
   const length = parameter.length;
   const type = typeof parameter;
@@ -19,5 +19,5 @@ export default function validateParameter(parameter: any, maxLength: number) {
     validatedParameter = parameter.substring(0, maxLength);
   }
 
-  return validatedParameter;
+  return validatedParameter.toLowerCase();
 }


### PR DESCRIPTION
### Description ###
- Add a new Navigation tracker based on GA4 implementation guide

### Tickets ###
(DFC-85)[https://govukverify.atlassian.net/browse/DFC-85]
(DFC-92)[https://govukverify.atlassian.net/browse/DFC-92]

### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

