### PR TITLE
DFC-80/DFC-81: add form response tracker

### DIFF
--- a/src/analytics/baseTracker/baseTracker.test.ts
+++ b/src/analytics/baseTracker/baseTracker.test.ts
@@ -37,7 +37,7 @@ describe("should return the good parameter values", () => {
   test("Get en as a default Language", () => {
     document.documentElement.lang = "";
     const languageCode = newInstance.getLanguage();
-    expect(languageCode).toEqual("en");
+    expect(languageCode).toEqual("undefined");
   });
 
   test("Get location from DOM", () => {

--- a/src/analytics/baseTracker/baseTracker.ts
+++ b/src/analytics/baseTracker/baseTracker.ts
@@ -41,7 +41,7 @@ export class BaseTracker {
     const languageCode =
       document.querySelector("html") &&
       document.querySelector("html")?.getAttribute("lang");
-    return languageCode?.toLowerCase() || "en";
+    return languageCode?.toLowerCase() || "undefined";
   }
 
   /**

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -18,7 +18,6 @@ export class Analytics {
     this.pageViewTracker = new PageViewTracker();
     this.navigationTracker = new NavigationTracker();
     this.formResponseTracker = new FormResponseTracker();
-    //this.formResponseTracker.trackFormResponse({});
     this.loadGtmScript();
   }
 

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -1,3 +1,4 @@
+import { FormResponseTracker } from "../formTracker/formTracker";
 import { NavigationTracker } from "../navigationTracker/navigationTracker";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
 
@@ -5,6 +6,7 @@ export class Analytics {
   gtmId: string;
   pageViewTracker: PageViewTracker;
   navigationTracker: NavigationTracker;
+  formResponseTracker: FormResponseTracker;
 
   /**
    * Initializes a new instance of the class.
@@ -15,6 +17,8 @@ export class Analytics {
     this.gtmId = gtmId;
     this.pageViewTracker = new PageViewTracker();
     this.navigationTracker = new NavigationTracker();
+    this.formResponseTracker = new FormResponseTracker();
+    //this.formResponseTracker.trackFormResponse({});
     this.loadGtmScript();
   }
 

--- a/src/analytics/formTracker/formTracker.interface.ts
+++ b/src/analytics/formTracker/formTracker.interface.ts
@@ -1,0 +1,19 @@
+export interface FormEventInterface {
+  event: string;
+  event_data: {
+    event_name: string;
+    type: string;
+    url: string;
+    text: string;
+    section: string;
+    action: string;
+    external: string;
+  };
+}
+
+export interface FormField {
+  id: string;
+  name: string;
+  value: string | undefined;
+  type: string;
+}

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -20,18 +20,6 @@ describe("FormResponseTracker", () => {
     expect(instance.initialiseEventListener).toBeCalled();
   });
 
-  /*
-    BUG: This test fails because it returns an error: "ReferenceError: SubmitEvent is not defined"
-    JIRA Ticket: https://jira.atlassian.com/browse/DFC-129
-    */
-  /*test("getButtonLabel should return button label", () => {
-        const instance = new FormResponseTracker();
-        const button = document.createElement("button");
-        button.textContent = "test";
-        const submitEvent = new SubmitEvent("submit",{ submitter: button});
-        expect(instance.getButtonLabel(submitEvent)).toBe("test");
-    });*/
-
   test("getFields should return a list of fields objects", () => {
     const instance = new FormResponseTracker();
     const form = document.createElement("form");

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { FormResponseTracker } from "./formTracker";
+import { FormField } from "./formTracker.interface";
+
+describe("FormResponseTracker", () => {
+  //const newInstance = new FormResponseTracker();
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+  const constructorSpy = jest.spyOn(
+    FormResponseTracker.prototype,
+    "initialiseEventListener",
+  );
+
+  test("new instance should call initialiseEventListener", () => {
+    const instance = new FormResponseTracker();
+    expect(instance.initialiseEventListener).toBeCalled();
+  });
+
+  /*
+    BUG: This test fails because it returns an error: "ReferenceError: SubmitEvent is not defined"
+    JIRA Ticket: https://jira.atlassian.com/browse/DFC-129
+    */
+  /*test("getButtonLabel should return button label", () => {
+        const instance = new FormResponseTracker();
+        const button = document.createElement("button");
+        button.textContent = "test";
+        const submitEvent = new SubmitEvent("submit",{ submitter: button});
+        expect(instance.getButtonLabel(submitEvent)).toBe("test");
+    });*/
+
+  test("getFields should return a list of fields objects", () => {
+    const instance = new FormResponseTracker();
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<input id="test" name="test" value="test value" type="text"/>';
+    document.body.appendChild(form);
+    expect(instance.getFields(form)).toEqual([
+      {
+        id: "test",
+        name: "test",
+        value: "test value",
+        type: "text",
+      },
+    ]);
+  });
+
+  test("getFieldValue should return field value", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "test" },
+    ];
+    expect(instance.getFieldValue(fields)).toBe("test value");
+  });
+
+  test("getFieldType should return free text field if type is text", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "text" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("free text field");
+  });
+
+  test("getFieldType should return free text field if type is textarea", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "textarea" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("free text field");
+  });
+
+  test("getFieldType should return drop-down list if type is select-one", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "select-one" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("drop-down list");
+  });
+
+  test("getFieldType should return checkbox if type is checkbox", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "checkbox" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("checkbox");
+  });
+
+  test("getFieldType should return radio if type is radio", () => {
+    const instance = new FormResponseTracker();
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "radio" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("radio");
+  });
+
+  test("getFieldLabel should return field label", () => {
+    const instance = new FormResponseTracker();
+    const label = document.createElement("label");
+    label.innerHTML = "test label";
+    label.textContent = "test label";
+    document.body.appendChild(label);
+    expect(instance.getFieldLabel()).toBe("test label");
+  });
+});
+describe("form with input checkbox", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const instance = new FormResponseTracker();
+    document.body.innerHTML = "";
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      "  <legend>test label questions</legend>" +
+      '  <label for="question-1">test label question 1</label>' +
+      '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
+      '  <label for="question-2">test label question 2</label>' +
+      '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "checkbox",
+        url: "undefined",
+        text: "test label question 1",
+        section: "test label questions",
+        action: "undefined",
+        external: "undefined",
+      },
+    };
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+describe("form with input text", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const instance = new FormResponseTracker();
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <input type="text" id="username" name="username" value="test value"/>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "free text field",
+        url: "undefined",
+        text: "test value",
+        section: "test label username",
+        action: "undefined",
+        external: "undefined",
+      },
+    };
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("form with input textarea", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const instance = new FormResponseTracker();
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <textarea id="username" name="username" value="test value"/>test value</textarea>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "free text field",
+        url: "undefined",
+        text: "test value",
+        section: "test label username",
+        action: "undefined",
+        external: "undefined",
+      },
+    };
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("form with dropdown", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const instance = new FormResponseTracker();
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "drop-down list",
+        url: "undefined",
+        text: "test value2",
+        section: "test label username",
+        action: "undefined",
+        external: "undefined",
+      },
+    };
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import { FormResponseTracker } from "./formTracker";
-import { FormField } from "./formTracker.interface";
+import { FormEventInterface, FormField } from "./formTracker.interface";
 
 describe("FormResponseTracker", () => {
   //const newInstance = new FormResponseTracker();
@@ -115,7 +115,7 @@ describe("form with input checkbox", () => {
       "</form>";
     document.dispatchEvent(action);
 
-    const dataLayerEvent = {
+    const dataLayerEvent: FormEventInterface = {
       event: "event_data",
       event_data: {
         event_name: "form_response",
@@ -148,7 +148,7 @@ describe("form with input text", () => {
       "</form>";
     document.dispatchEvent(action);
 
-    const dataLayerEvent = {
+    const dataLayerEvent: FormEventInterface = {
       event: "event_data",
       event_data: {
         event_name: "form_response",
@@ -182,7 +182,7 @@ describe("form with input textarea", () => {
       "</form>";
     document.dispatchEvent(action);
 
-    const dataLayerEvent = {
+    const dataLayerEvent: FormEventInterface = {
       event: "event_data",
       event_data: {
         event_name: "form_response",
@@ -216,7 +216,7 @@ describe("form with dropdown", () => {
       "</form>";
     document.dispatchEvent(action);
 
-    const dataLayerEvent = {
+    const dataLayerEvent: FormEventInterface = {
       event: "event_data",
       event_data: {
         event_name: "form_response",

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -1,6 +1,105 @@
-function formTracker() {
-  console.log("running formTracker");
-  return "";
-}
+import { BaseTracker } from "../baseTracker/baseTracker";
 
-export default formTracker;
+export class FormResponseTracker extends BaseTracker {
+  eventName: string = "form_response";
+  eventType: string = "event_data";
+
+  constructor() {
+    super();
+    this.initialiseEventListener();
+  }
+
+  initialiseEventListener() {
+    document.addEventListener(
+      "submit",
+      this.trackFormResponse.bind(this),
+      false,
+    );
+  }
+
+  trackFormResponse(event: SubmitEvent): boolean {
+    event.preventDefault();
+
+    const form = document.forms[0];
+    console.log("form action", form.action);
+    console.log("fieldset", form.elements[0]);
+    console.log("event type", event.target);
+
+    console.log("form button label", event.submitter?.textContent?.trim());
+    event.currentTarget;
+    const data = new FormData(event.target as any);
+    //console.log('data action',event.currentTarget)
+    console.log("data entries", data.keys());
+    data.forEach((value, key) => {
+      console.log("key", key);
+      console.log("value", value);
+    });
+
+    const value = Object.fromEntries(data.entries());
+    console.log("value", { value });
+    //this.getFieldLabel();
+    this.getFieldType(form);
+
+    //console.log("form elements", form.elements);
+    //this.getFormElements(form.elements as any);
+    //remove fields type hidden
+
+    //console.log("button", form.);
+
+    const formResponseTrackerEvent: any = {
+      event: this.eventType,
+      event_data: {
+        event_name: this.eventName,
+        type: this.getFieldType(form),
+        url: this.getLocation(),
+        text: this.getFieldValue(form),
+        section: this.getFieldLabel(),
+        action: event.submitter?.textContent
+          ? event.submitter.textContent.trim()
+          : "undefined",
+        external: "undefined",
+      },
+    };
+
+    /*try {
+      this.pushToDataLayer(formResponseTrackerEvent);
+      return true;
+    } catch (err) {
+      console.error("Error in trackFormResponses", err);
+      return false;
+    }*/
+    return false;
+  }
+
+  getFieldType(form: HTMLFormElement): string {
+    const inputs = form.getElementsByTagName("input");
+    if (!inputs.length) {
+      return "undefined";
+    }
+    console.log("input type", inputs[0].type);
+    return inputs[0].type;
+  }
+
+  getFieldLabel(): string {
+    const labels: HTMLCollectionOf<HTMLLegendElement> =
+      document.getElementsByTagName("legend");
+    if (!labels.length) {
+      return "undefined";
+    }
+    let label: string = "";
+    for (let i = 0; i < labels.length; i++) {
+      if (labels[i].textContent) {
+        label += labels[i]?.textContent?.trim() + " ";
+      }
+    }
+    return label;
+  }
+
+  getFieldValue(form: HTMLFormElement): string {
+    return "field value";
+  }
+
+  getButtonLabel(form: HTMLFormElement): string {
+    return "button label";
+  }
+}

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -11,7 +11,7 @@ describe("validateParameter", () => {
   test("invalid types should be replaced by an error message", () => {
     const parameter = 1234;
     const validatedParameter = validateParameter(parameter, 100);
-    expect(validatedParameter).toEqual("invalid type provided");
+    expect(validatedParameter).toEqual("undefined");
   });
 
   test("parameters with invalid lengths should be truncated", () => {
@@ -23,6 +23,6 @@ describe("validateParameter", () => {
   test("empty parameters should be replaced with error message", () => {
     const parameter = "";
     const validatedParameter = validateParameter(parameter, 100);
-    expect(validatedParameter).toEqual("no parameter provided");
+    expect(validatedParameter).toEqual("undefined");
   });
 });

--- a/src/utils/validateParameter.ts
+++ b/src/utils/validateParameter.ts
@@ -3,7 +3,7 @@
  */
 
 export function validateParameter(parameter: any, maxLength: number) {
-  let validatedParameter = parameter || "No parameter provided";
+  let validatedParameter = parameter || "undefined";
   const length = parameter.length;
   const type = typeof parameter;
 
@@ -11,7 +11,7 @@ export function validateParameter(parameter: any, maxLength: number) {
     console.error(
       `GA4: Invalid data type found, ${parameter} should be a string but instead found a ${type}`,
     );
-    validatedParameter = "Invalid type provided";
+    validatedParameter = "undefined";
   } else if (length > maxLength) {
     console.error(
       `GA4: ${parameter} should not be more than ${maxLength} characters, it is currently ${length} characters long`,


### PR DESCRIPTION
### Description ###
Add the Form Response Tracker:
- Add listener on form submit
- Manage all fields type values

### Tickets ###
(DFC-80)[https://govukverify.atlassian.net/browse/DFC-80]
(DFC-81)[https://govukverify.atlassian.net/browse/DFC-81]
### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

