### PR TITLE
Amend generic button logic and tests

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -140,9 +140,9 @@ describe("getLinkType", () => {
     expect(newInstance.getLinkType(element)).toBe("generic link");
   });
 
-  test('should return "generic button" when the element is a <button> tag', () => {
-    const button = document.createElement("BUTTON");
-    button.className = "other-link";
+  test('should return "generic button" when the element is a has a tag and button classname', () => {
+    const button = document.createElement("A");
+    button.className = "govuk-button";
     button.dispatchEvent(action);
     const element = action.target as HTMLLinkElement;
     expect(newInstance.getLinkType(element)).toBe("generic button");

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -38,9 +38,9 @@ export class NavigationTracker extends BaseTracker {
     ]);
 
     /**
-     * Navigation tracker is only for links and buttons
+     * Navigation tracker is only for links
      */
-    if (element.tagName !== "A" && element.tagName !== "BUTTON") {
+    if (element.tagName !== "A") {
       return false;
     }
     // Ignore links that don't have an inbound or outbound href
@@ -119,7 +119,7 @@ export class NavigationTracker extends BaseTracker {
    * Returns the type of link based on the given HTML link element.
    *
    * @param {HTMLLinkElement} element - The HTML link element to get the type of.
-   * @return {string} The type of link: "footer", "header menu bar", "generic link", "generic button", or "undefined".
+   * @return {string} The type of link: "footer", "header menu bar", "generic link", or "undefined".
    */
   getLinkType(element: HTMLLinkElement): string {
     if (element.tagName === "A") {
@@ -127,10 +127,10 @@ export class NavigationTracker extends BaseTracker {
         return "footer";
       } else if (this.isHeaderMenuBarLink(element)) {
         return "header menu bar";
+      } else if (element.classList.contains("govuk-button")) {
+        return "generic button";
       }
       return "generic link";
-    } else if (element.tagName === "BUTTON") {
-      return "generic button";
     }
     return "undefined"; // generic button
   }


### PR DESCRIPTION
### Description ###
This PR updates the logic which searches for 'button' elements, and replaces this lookup with class names

### Tickets ###
(DFC-143)[https://govukverify.atlassian.net/browse/DFC-143]

### Steps to Reproduce ###

GA4 Demo app
`npm run dev` this means you will not need to restart the server everytime there is a change when testing the ga4 tracker changes

GA4 app
Run `npm build` this will build the latest code in the analytics.js file then…
run `cp dist/lib/analytics.js ../di-fec-ga4-demo/node_modules/one-login-ga4/lib` this will copy the bundled file to the GA4 Demo app as a ‘mock’ type file, and overwrite the node modules version from the NPM registry - this command will only work if you have your repos in the same directory, otherwise replace the with your relative path

When you select any 'govuk-button' this will come through on the nav tracker as 'generic-button' as type

![Screenshot 2023-12-05 at 11 43 44](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/d4c1da72-3190-4d59-9602-a0e23bcfca75)


