### PR TITLE
Add functionality to set phase banner

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -120,6 +120,18 @@ describe("getLinkType", () => {
     expect(newInstance.getLinkType(element)).toBe("footer");
   });
 
+  test('should return "header menu bar" when the element is an <a> tag within the phase banner', () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-phase-banner'></div>";
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    phaseBanner.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getLinkType(element)).toBe("header menu bar");
+  });
+
   test('should return "header menu bar" when the element is an <a> tag within the header tag', () => {
     const href = document.createElement("A");
     href.className = "header__navigation";

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -125,7 +125,10 @@ export class NavigationTracker extends BaseTracker {
     if (element.tagName === "A") {
       if (this.isFooterLink(element)) {
         return "footer";
-      } else if (this.isHeaderMenuBarLink(element)) {
+      } else if (
+        this.isHeaderMenuBarLink(element) ||
+        this.isPhaseBannerLink(element)
+      ) {
         return "header menu bar";
       } else if (element.classList.contains("govuk-button")) {
         return "generic button";
@@ -134,7 +137,6 @@ export class NavigationTracker extends BaseTracker {
     }
     return "undefined"; // generic button
   }
-
   /**
    * Determines whether the given class name is a footer link.
    *
@@ -143,7 +145,7 @@ export class NavigationTracker extends BaseTracker {
    */
   isFooterLink(element: HTMLElement): boolean {
     const footer = document.getElementsByTagName("footer")[0];
-    return footer.contains(element);
+    return footer && footer.contains(element);
   }
 
   /**
@@ -154,6 +156,12 @@ export class NavigationTracker extends BaseTracker {
    */
   isHeaderMenuBarLink(element: HTMLElement): boolean {
     const header = document.getElementsByTagName("header")[0];
-    return header.contains(element);
+    return header && header.contains(element);
+  }
+
+  isPhaseBannerLink(element: HTMLElement): boolean {
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    return phaseBanner && phaseBanner.contains(element);
   }
 }


### PR DESCRIPTION
Description
Adds logic to set the phase banner links on navigation change

Tickets
(DFC-129)[https://govukverify.atlassian.net/browse/DFC-129]

Steps to Reproduce
Click on the phase banner links
Validate this on local + gtm
Added header, footer and phase banner check as the tests were failing without them


