### PR TITLE
Dfc 159 manage the section property

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -261,13 +261,13 @@ describe("getSection", () => {
     expect(newInstance.getSection(element)).toBe("phase banner");
   });
 
-  test("it should return menu links when a link is clicked in the menu links", () => {
+  test("it should return menu links when a link is clicked in the header", () => {
     const href = document.createElement("A");
     href.className = "govuk-link";
     href.dispatchEvent(action);
-    document.body.innerHTML = "<nav id='app-navigation'></nav>";
-    const navigation = document.getElementsByTagName("nav")[0];
-    navigation.appendChild(href);
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(href);
     const element = action.target as HTMLLinkElement;
     expect(newInstance.getSection(element)).toBe("menu links");
   });

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -222,3 +222,94 @@ describe("isBackLink", () => {
     expect(newInstance.isBackLink(element)).toBe(false);
   });
 });
+
+describe("getSection", () => {
+  const newInstance = new NavigationTracker();
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test("it should return undefined if section is not defined", () => {
+    document.body.innerHTML = `<body><a id="testLink1">Link to GOV.UK</a></body>`;
+    const element = document.getElementById("testLink1") as HTMLElement;
+    expect(newInstance.getSection(element)).toBe("undefined");
+  });
+
+  test("it should return logo when a link is clicked in the logo", () => {
+    const element = document.createElement("span");
+    element.className = "govuk-header__logotype";
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(element);
+    element.dispatchEvent(action);
+    element.addEventListener("click", (event) => {
+      expect(newInstance.getSection(element)).toBe("logo");
+    });
+  });
+
+  test("it should return phase banner when a link is clicked in the phase banner", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-phase-banner'></div>";
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    phaseBanner.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getSection(element)).toBe("phase banner");
+  });
+
+  test("it should return menu links when a link is clicked in the menu links", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<nav id='app-navigation'></nav>";
+    const navigation = document.getElementsByTagName("nav")[0];
+    navigation.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getSection(element)).toBe("menu links");
+  });
+
+  test("it should return support links when a link is clicked in the support links", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-footer__inline-list'></div>";
+    const footerInlineList = document.getElementsByClassName(
+      "govuk-footer__inline-list",
+    )[0];
+    footerInlineList.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getSection(element)).toBe("support links");
+  });
+
+  test("it should return license links when a link is clicked in the license link", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML =
+      "<span class='govuk-footer__licence-description'></span>";
+    const license = document.getElementsByClassName(
+      "govuk-footer__licence-description",
+    )[0];
+    license.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getSection(element)).toBe("license");
+  });
+
+  test("it should return copyright when a link is clicked on copyright image", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML =
+      "<span class='govuk-footer__copyright-logo'></span>";
+    const copyright = document.getElementsByClassName(
+      "govuk-footer__copyright-logo",
+    )[0];
+    copyright.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(newInstance.getSection(element)).toBe("copyright");
+  });
+});

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -192,7 +192,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given class nam is a phase banner link
+   * Determines if the given class name is a phase banner link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
@@ -204,7 +204,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given class nam is a back button link.
+   * Determines if the given class name is a back button link.
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-back-link", false otherwise.
@@ -226,7 +226,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given class namis a nav link.
+   * Determines if the given tagname is a is a nav link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the nav tag contains this element, false otherwise.

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -4,7 +4,6 @@ import { validateParameter } from "../../utils/validateParameter";
 
 export class NavigationTracker extends BaseTracker {
   eventName: string = "event_data";
-  section: string = "undefined";
 
   constructor() {
     super();
@@ -62,7 +61,7 @@ export class NavigationTracker extends BaseTracker {
         text: element.textContent
           ? validateParameter(element.textContent.trim(), 100)
           : "undefined",
-        section: this.section,
+        section: this.getSection(element),
         action: "undefined",
         external: this.isExternalLink(element.href) ? "true" : "false",
         link_domain: this.getDomain(element.href),
@@ -145,6 +144,25 @@ export class NavigationTracker extends BaseTracker {
     }
     return "undefined"; // generic button
   }
+
+  getSection(element: HTMLElement): string {
+    // if header
+    if (this.isLogoLink(element)) {
+      return "logo";
+    } else if (this.isPhaseBannerLink(element)) {
+      return "phase banner";
+    } else if (this.isNavLink(element)) {
+      return "menu links";
+    } else if (this.isSupportLink(element)) {
+      return "support links";
+    } else if (this.isLicenseLink(element)) {
+      return "license";
+    } else if (this.isCopyright(element)) {
+      return "copyright";
+    }
+    return "undefined";
+  }
+
   /**
    * Determines whether the given class name is a footer link.
    *
@@ -157,16 +175,22 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given class name is a header menu bar link.
+   * Determines if the given element is a phase banner link
    *
    * @param {string} element - The HTML link element to get the type of.
-   * @return {boolean} Returns true if the header tag contains this element, false otherwise.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
    */
   isHeaderMenuBarLink(element: HTMLElement): boolean {
     const header = document.getElementsByTagName("header")[0];
     return header && header.contains(element);
   }
 
+  /**
+   * Determines if the given element is a phase banner link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
+   */
   isPhaseBannerLink(element: HTMLElement): boolean {
     const phaseBanner =
       document.getElementsByClassName("govuk-phase-banner")[0];
@@ -182,5 +206,66 @@ export class NavigationTracker extends BaseTracker {
   isBackLink(element: HTMLElement): boolean {
     const elementClassName: string = element.className as string;
     return elementClassName.includes("govuk-back-link");
+  }
+
+  /**
+   * Determines if the given element is a phase banner link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-header__logo", false otherwise.
+   */
+  isLogoLink(element: HTMLElement): boolean {
+    const logo = document.getElementsByClassName("govuk-header__logo")[0];
+    return logo && logo.contains(element);
+  }
+
+  /**
+   * Determines whether the given class name is a nav link.
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the nav tag contains this element, false otherwise.
+   */
+  isNavLink(element: HTMLElement): boolean {
+    const nav = document.getElementsByTagName("nav")[0];
+    return nav && nav.contains(element);
+  }
+
+  /**
+   * Determines if the given element is a in-line support link link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__inline-list", false otherwise.
+   */
+  isSupportLink(element: HTMLElement): boolean {
+    const supportLinks = document.getElementsByClassName(
+      "govuk-footer__inline-list",
+    )[0];
+    return supportLinks && supportLinks.contains(element);
+  }
+
+  /**
+   * Determines if the given element is a in-line license link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__licence-description", false otherwise.
+   */
+  isLicenseLink(element: HTMLElement): boolean {
+    const supportLinks = document.getElementsByClassName(
+      "govuk-footer__licence-description",
+    )[0];
+    return supportLinks && supportLinks.contains(element);
+  }
+
+  /**
+   * Determines if the given element is within the copyright logo
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__copyright-logo", false otherwise.
+   */
+  isCopyright(element: HTMLElement): boolean {
+    const licenseLinks = document.getElementsByClassName(
+      "govuk-footer__copyright-logo",
+    )[0];
+    return licenseLinks && licenseLinks.contains(element);
   }
 }

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -124,7 +124,7 @@ export class NavigationTracker extends BaseTracker {
    * Returns the type of link based on the given HTML link element.
    *
    * @param {HTMLLinkElement} element - The HTML link element to get the type of.
-   * @return {string} The type of link: "footer", "header menu bar", "generic link", or "undefined".
+   * @return {string} The type of link: "footer", "header menu bar", "generic link", "generic button", or "undefined".
    */
   getLinkType(element: HTMLLinkElement): string {
     if (element.tagName === "A") {
@@ -142,9 +142,15 @@ export class NavigationTracker extends BaseTracker {
       }
       return "generic link";
     }
-    return "undefined"; // generic button
+    return "undefined";
   }
 
+  /**
+   * Returns the type of section based on the given HTML link element.
+   *
+   * @param {HTMLLinkElement} element - The HTML link element to get the type of.
+   * @return {string} The section: "logo", "phase banner", "menu links", "support links", "license", "copyright" or "undefined".
+   */
   getSection(element: HTMLElement): string {
     // if header
     if (this.isLogoLink(element)) {
@@ -175,7 +181,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a phase banner link
+   * Determines if the given element is a header link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
@@ -186,7 +192,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a phase banner link
+   * Determines if the given class nam is a phase banner link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
@@ -198,7 +204,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a back button link.
+   * Determines if the given class nam is a back button link.
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-back-link", false otherwise.
@@ -209,7 +215,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a phase banner link
+   * Determines if the given class name is a logo link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-header__logo", false otherwise.
@@ -220,7 +226,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines whether the given class name is a nav link.
+   * Determines if the given class namis a nav link.
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the nav tag contains this element, false otherwise.
@@ -231,7 +237,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a in-line support link link
+   * Determines if the given class name is a support link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-footer__inline-list", false otherwise.
@@ -244,7 +250,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is a in-line license link
+   * Determines if the given class name is a license link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-footer__licence-description", false otherwise.
@@ -257,7 +263,7 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given element is within the copyright logo
+   * Determines if the given class name is a copyright logo
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-footer__copyright-logo", false otherwise.

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -184,7 +184,7 @@ export class NavigationTracker extends BaseTracker {
    * Determines if the given element is a header link
    *
    * @param {string} element - The HTML link element to get the type of.
-   * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
+   * @return {boolean} Returns true if the header tag contains this element, false otherwise.
    */
   isHeaderMenuBarLink(element: HTMLElement): boolean {
     const header = document.getElementsByTagName("header")[0];

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -232,8 +232,11 @@ export class NavigationTracker extends BaseTracker {
    * @return {boolean} Returns true if the nav tag contains this element, false otherwise.
    */
   isNavLink(element: HTMLElement): boolean {
-    const nav = document.getElementsByTagName("nav")[0];
-    return nav && nav.contains(element);
+    const elementClassName: string = element.className as string;
+    const isLink = elementClassName.includes("govuk-link");
+    const header = document.getElementsByTagName("header")[0];
+
+    return header && header.contains(element) && isLink;
   }
 
   /**


### PR DESCRIPTION
### Tickets ###
(DFC-159)[https://govukverify.atlassian.net/browse/DFC-159]

### Steps to Reproduce ###
Adds the section property based on the link section the a link parent element


![Screenshot 2023-12-11 at 11 26 19](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/e89cc314-5cc3-41a1-8754-9d68c78e0aa6)
![Screenshot 2023-12-11 at 11 25 56](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/10035c79-da46-412b-9990-80927f590d20)
![Screenshot 2023-12-11 at 11 25 18](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/aebc9001-6608-487c-99e8-15eac25b6eaa)
![Screenshot 2023-12-11 at 11 25 11](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/29ef14e7-1969-4f31-a6f1-fe6730698f79)
![Screenshot 2023-12-11 at 11 24 57](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/a9a142f2-98da-4f1f-8558-7ca336ed9a41)
![Screenshot 2023-12-07 at 14 26 38](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/64a57401-7f44-40ee-8a9f-03e30fe76a1b)

The only element which is hard to test is the tag 'nav' which out outs 'menu-links' according to the documentation link here (number 2)
![image](https://github.com/govuk-one-login/di-fec-ga4/assets/38694448/b7c8f6a0-2677-4434-a2f4-f813d73ed2dd)
Note: this is not header links which is part of the header component

The only example I can find on the design system is on the GOV design system site, which uses the 'nav' tag 
https://design-system.service.gov.uk/components/







