### PR TITLE
DFC-164: fix radio type error

### DIFF
--- a/src/analytics/formErrorTracker/formErrorTracker.test.ts
+++ b/src/analytics/formErrorTracker/formErrorTracker.test.ts
@@ -124,4 +124,22 @@ describe("FormErrorTracker", () => {
     const form = document.forms[0];
     expect(instance.getType(form)).toEqual("drop-down list");
   });
+
+  test("getType with radio buttons field should return the type radio buttons", () => {
+    const instance = new FormErrorTracker();
+
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      "  <legend>test label questions</legend>" +
+      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
+      '  <label for="male">test label male</label>' +
+      '  <input type="radio" id="male" name="male" value="Male" checked/>' +
+      '  <label for="female">test label female</label>' +
+      '  <input type="radio" id="female" name="female" value="Male"/>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+
+    const form = document.forms[0];
+    expect(instance.getType(form)).toEqual("radio buttons");
+  });
 });

--- a/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -46,7 +46,7 @@ describe("form with radio buttons", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: "radio",
+        type: "radio buttons",
         url: "undefined",
         text: "test label male",
         section: "test label questions",

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -61,12 +61,12 @@ describe("FormTracker", () => {
     expect(instance.getFieldType(fields)).toBe("checkbox");
   });
 
-  test("getFieldType should return radio if type is radio", () => {
+  test("getFieldType should return radio buttons if type is radio", () => {
     const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "radio" },
     ];
-    expect(instance.getFieldType(fields)).toBe("radio");
+    expect(instance.getFieldType(fields)).toBe("radio buttons");
   });
 
   test("getFieldLabel should return field label", () => {

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -4,6 +4,7 @@ import { FormField } from "./formTracker.interface";
 export class FormTracker extends BaseTracker {
   FREE_TEXT_FIELD_TYPE = "free text field";
   DROPDOWN_FIELD_TYPE = "drop-down list";
+  RADIO_FIELD_TYPE = "radio buttons";
 
   constructor() {
     super();
@@ -74,6 +75,8 @@ export class FormTracker extends BaseTracker {
       return this.FREE_TEXT_FIELD_TYPE;
     } else if (elements[0].type === "select-one") {
       return this.DROPDOWN_FIELD_TYPE;
+    } else if (elements[0].type === "radio") {
+      return this.RADIO_FIELD_TYPE;
     } else {
       return elements[0].type;
     }


### PR DESCRIPTION
### Description ###
In the form trackers, radio form is identify with the type “radio“ instead of “radio buttons“.

### Tickets ###
(DFC-164)[https://govukverify.atlassian.net/browse/DFC-164]

### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

