### PR TITLE
DFC-165: fix form change tracker values error

### DIFF
--- a/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -42,9 +42,9 @@ describe("FormChangeTracker", () => {
         event_name: "form_change_response",
         type: "undefined",
         url: "undefined",
-        text: "undefined",
+        text: "change", //put static value. Waiting final documentation on form change tracker
         section: "test label questions",
-        action: instance.getSubmitterText(),
+        action: "change response",
         external: "undefined",
       },
     };

--- a/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -32,9 +32,9 @@ export class FormChangeTracker extends FormTracker {
         event_name: this.eventName,
         type: "undefined",
         url: "undefined",
-        text: "undefined",
+        text: "change", //put static value. Waiting final documentation on form change tracker,
         section: validateParameter(this.getFieldLabel(), 100),
-        action: validateParameter(this.getSubmitterText(), 100),
+        action: "change response",
         external: "undefined",
       },
     };


### PR DESCRIPTION
### Description ###
Further updates to values need to be made. In accordance to [documentation](https://govukverify.atlassian.net/wiki/spaces/PI/pages/3603791886/WIP+GA4+Implementation+Guide#Form-Change-Response-IN-SCOPE) , the action parameter value should be “change response”  and text should be “change” to reflect text of link.

### Tickets ###
(DFC-165)[https://govukverify.atlassian.net/browse/DFC-165]

### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

