### PR TITLE
DFC-186| Update response tracker to be able to manage multiple fields

### DIFF
--- a/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -3,6 +3,141 @@ import { FormResponseTracker } from "./formResponseTracker";
 import { FormEventInterface } from "../formTracker/formTracker.interface";
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
+describe("form with multiple fields", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
+
+  test("event fired and data layer defined for each of the fields", () => {
+    const instance = new FormResponseTracker();
+    document.body.innerHTML =
+      '<form action= "/test-url" method= "post">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="question-1">checked value</label>' +
+      '  <input type="checkbox" id="question-1" name="question-1" value="checked value" checked/>' +
+      '  <label for="question-2">unchecked value</label>' +
+      '  <input type="checkbox" id="question-2" name="question-2" value="unchecked value"/>' +
+      "</fieldset>" +
+      '  <label for="region">dropdown section</label>' +
+      '  <select id="region" name="region"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <label for="username">text input section</label>' +
+      '  <input type="text" id="username" name="username" value="test value"/>' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="male" value="radio value" checked/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="female" value="radio value 2"/>' +
+      "</fieldset>" +
+      '  <label for="feedback">textarea section</label>' +
+      '  <textarea id="feedback" name="feedback" value="test value"/>test value</textarea>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+    document.dispatchEvent(action);
+
+    const dataLayerEventCheckbox: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "checked value",
+        section: "checked section",
+        action: "undefined",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    const dataLayerEventDropdown: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "drop-down list",
+        url: "http://localhost/test-url",
+        text: "test value2",
+        section: "dropdown section",
+        action: "undefined",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventText: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "test value",
+        section: "text input section",
+        action: "undefined",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventRadio: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "radio value",
+        section: "radio section",
+        action: "undefined",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventTextarea: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "test value",
+        section: "textarea section",
+        action: "undefined",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventCheckbox);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventDropdown);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventText);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventRadio);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventTextarea);
+  });
+});
+
 describe("FormResponseTracker", () => {
   const action = new Event("submit", {
     bubbles: true,
@@ -33,13 +168,14 @@ describe("form with radio buttons", () => {
     const instance = new FormResponseTracker();
     document.body.innerHTML =
       '<form action="/test-url" method="post">' +
+      "<fieldset>" +
       "  <legend>test label questions</legend>" +
       '  <label for="male">test label male</label>' +
       '  <input type="radio" id="male" name="male" value="Male" checked/>' +
       '  <label for="female">test label female</label>' +
       '  <input type="radio" id="female" name="female" value="Male"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
+      "</fieldset>";
+    '  <button id="button" type="submit">submit</button>' + "</form>";
     document.dispatchEvent(action);
 
     const dataLayerEvent: FormEventInterface = {
@@ -77,13 +213,14 @@ describe("form with input checkbox", () => {
 
     document.body.innerHTML =
       '<form action="/test-url" method="post">' +
+      "<fieldset>" +
       "  <legend>test label questions</legend>" +
       '  <label for="question-1">test label question 1</label>' +
       '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
       '  <label for="question-2">test label question 2</label>' +
       '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
+      "</fieldset>";
+    '  <button id="button" type="submit">submit</button>' + "</form>";
     document.dispatchEvent(action);
 
     const dataLayerEvent: FormEventInterface = {

--- a/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -19,8 +19,8 @@ describe("form with multiple fields", () => {
       "  <legend>checked section</legend>" +
       '  <label for="question-1">checked value</label>' +
       '  <input type="checkbox" id="question-1" name="question-1" value="checked value" checked/>' +
-      '  <label for="question-2">unchecked value</label>' +
-      '  <input type="checkbox" id="question-2" name="question-2" value="unchecked value"/>' +
+      '  <label for="question-2">checked value2</label>' +
+      '  <input type="checkbox" id="question-2" name="question-1" value="checked value2" checked/>' +
       "</fieldset>" +
       '  <label for="region">dropdown section</label>' +
       '  <select id="region" name="region"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
@@ -29,9 +29,9 @@ describe("form with multiple fields", () => {
       "<fieldset>" +
       "  <legend>radio section</legend>" +
       '  <label for="male">radio value</label>' +
-      '  <input type="radio" id="male" name="male" value="radio value" checked/>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value" checked/>' +
       '  <label for="female">radio value 2</label>' +
-      '  <input type="radio" id="female" name="female" value="radio value 2"/>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
       "</fieldset>" +
       '  <label for="feedback">textarea section</label>' +
       '  <textarea id="feedback" name="feedback" value="test value"/>test value</textarea>' +
@@ -45,7 +45,7 @@ describe("form with multiple fields", () => {
         event_name: "form_response",
         type: "checkbox",
         url: "http://localhost/test-url",
-        text: "checked value",
+        text: "checked value, checked value2",
         section: "checked section",
         action: "undefined",
         external: "undefined",

--- a/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -18,9 +18,9 @@ describe("form with multiple fields", () => {
       "<fieldset>" +
       "  <legend>checked section</legend>" +
       '  <label for="question-1">checked value</label>' +
-      '  <input type="checkbox" id="question-1" name="question-1" value="checked value" checked/>' +
+      '  <input type="checkbox" id="question-1" name="question-1" value="checkedValue" checked/>' +
       '  <label for="question-2">checked value2</label>' +
-      '  <input type="checkbox" id="question-2" name="question-1" value="checked value2" checked/>' +
+      '  <input type="checkbox" id="question-2" name="question-1" value="checkedValue2" checked/>' +
       "</fieldset>" +
       '  <label for="region">dropdown section</label>' +
       '  <select id="region" name="region"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
@@ -215,10 +215,10 @@ describe("form with input checkbox", () => {
       '<form action="/test-url" method="post">' +
       "<fieldset>" +
       "  <legend>test label questions</legend>" +
-      '  <label for="question-1">test label question 1</label>' +
-      '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
-      '  <label for="question-2">test label question 2</label>' +
-      '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
+      '  <label for="question-1">test value</label>' +
+      '  <input type="checkbox" id="question-1" name="question-1" value="testValue" checked/>' +
+      '  <label for="question-2">test value2</label>' +
+      '  <input type="checkbox" id="question-2" name="question-2" value="testValue2"/>' +
       "</fieldset>";
     '  <button id="button" type="submit">submit</button>' + "</form>";
     document.dispatchEvent(action);
@@ -229,7 +229,7 @@ describe("form with input checkbox", () => {
         event_name: "form_response",
         type: "checkbox",
         url: "http://localhost/test-url",
-        text: "test label question 1",
+        text: "test value",
         section: "test label questions",
         action: "undefined",
         external: "undefined",

--- a/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -52,7 +52,6 @@ export class FormResponseTracker extends FormTracker {
 
     if (form && form.elements) {
       fields = this.getFormFields(form);
-      console.log(fields);
     } else {
       return false;
     }

--- a/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -74,7 +74,7 @@ export class FormResponseTracker extends FormTracker {
             type: validateParameter(this.getFieldType([field]), 100),
             url: validateParameter(submitUrl, 100),
             text: validateParameter(this.getFieldValue([field]), 100),
-            section: validateParameter(this.getSectionValue([field]), 100),
+            section: validateParameter(this.getSectionValue(field), 100),
             action: validateParameter(this.getButtonLabel(event), 100),
             external: "undefined",
             link_domain: this.getDomain(submitUrl),

--- a/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -52,6 +52,7 @@ export class FormResponseTracker extends FormTracker {
 
     if (form && form.elements) {
       fields = this.getFormFields(form);
+      console.log(fields);
     } else {
       return false;
     }
@@ -61,37 +62,42 @@ export class FormResponseTracker extends FormTracker {
       return false;
     }
 
-    const submitUrl = this.getSubmitUrl(form);
-
-    const formResponseTrackerEvent: FormEventInterface = {
-      event: this.eventType,
-      event_data: {
-        event_name: this.eventName,
-        type: validateParameter(this.getFieldType(fields), 100),
-        url: validateParameter(submitUrl, 100),
-        text: validateParameter(this.getFieldValue(fields), 100),
-        section: validateParameter(this.getFieldLabel(), 100),
-        action: validateParameter(this.getButtonLabel(event), 100),
-        external: "undefined",
-        link_domain: this.getDomain(submitUrl),
-        "link_path_parts.1": this.getDomainPath(submitUrl, 0),
-        "link_path_parts.2": this.getDomainPath(submitUrl, 1),
-        "link_path_parts.3": this.getDomainPath(submitUrl, 2),
-        "link_path_parts.4": this.getDomainPath(submitUrl, 3),
-        "link_path_parts.5": this.getDomainPath(submitUrl, 4),
-      },
-    };
-
-    //don't track free text if disableFreeTextTracking is set
-    if (
-      this.disableFreeTextTracking &&
-      formResponseTrackerEvent.event_data.type === this.FREE_TEXT_FIELD_TYPE
-    ) {
-      return false;
-    }
-
     try {
-      this.pushToDataLayer(formResponseTrackerEvent);
+      // Iterate through each form field and generate an event for each
+      for (const field of fields) {
+        const submitUrl = this.getSubmitUrl(form);
+
+        const formResponseTrackerEvent: FormEventInterface = {
+          event: this.eventType,
+          event_data: {
+            event_name: this.eventName,
+            type: validateParameter(this.getFieldType([field]), 100),
+            url: validateParameter(submitUrl, 100),
+            text: validateParameter(this.getFieldValue([field]), 100),
+            section: validateParameter(this.getSectionValue([field]), 100),
+            action: validateParameter(this.getButtonLabel(event), 100),
+            external: "undefined",
+            link_domain: this.getDomain(submitUrl),
+            "link_path_parts.1": this.getDomainPath(submitUrl, 0),
+            "link_path_parts.2": this.getDomainPath(submitUrl, 1),
+            "link_path_parts.3": this.getDomainPath(submitUrl, 2),
+            "link_path_parts.4": this.getDomainPath(submitUrl, 3),
+            "link_path_parts.5": this.getDomainPath(submitUrl, 4),
+          },
+        };
+
+        // Don't track free text if disableFreeTextTracking is set
+        if (
+          this.disableFreeTextTracking &&
+          formResponseTrackerEvent.event_data.type === this.FREE_TEXT_FIELD_TYPE
+        ) {
+          return false; // Skip tracking for this field
+        }
+
+        // Push the event to the data layer for each field
+        this.pushToDataLayer(formResponseTrackerEvent);
+      }
+
       return true;
     } catch (err) {
       console.error("Error in trackFormResponse", err);

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -13,7 +13,6 @@ describe("FormTracker", () => {
     document.body.innerHTML = "";
   });
   test("getFields should return a list of fields objects", () => {
-    const instance = new FormTracker();
     const form = document.createElement("form");
     form.innerHTML =
       '<input id="test" name="test" value="test value" type="text"/>';
@@ -24,6 +23,23 @@ describe("FormTracker", () => {
         name: "test",
         value: "test value",
         type: "text",
+      },
+    ]);
+  });
+  test("getFormFields should return checkbox values as string , separated by commas if part of checkbox group", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      ' <label for="test">test value</label>' +
+      '<input id="test" name="test" value="test value" type="checkbox" checked/>' +
+      ' <label for="test1">test value2</label>' +
+      '<input id="test1" name="test" value="test value2" type="checkbox" checked/>';
+    document.body.appendChild(form);
+    expect(instance.getFormFields(form)).toEqual([
+      {
+        id: "test",
+        name: "test",
+        value: "test value, test value2",
+        type: "checkbox",
       },
     ]);
   });

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, jest, test } from "@jest/globals";
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
 import { FormTracker } from "./formTracker";
 import { FormEventInterface, FormField } from "./formTracker.interface";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("FormTracker", () => {
+  let instance: FormTracker;
+
+  beforeEach(() => {
+    instance = new FormTracker();
+    // Remove any existing elements from document.body if needed
+    document.body.innerHTML = "";
+  });
   test("getFields should return a list of fields objects", () => {
     const instance = new FormTracker();
     const form = document.createElement("form");
@@ -22,7 +29,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldValue should return field value", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "test" },
     ];
@@ -30,7 +36,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldType should return free text field if type is text", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "text" },
     ];
@@ -38,7 +43,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldType should return free text field if type is textarea", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "textarea" },
     ];
@@ -46,7 +50,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldType should return drop-down list if type is select-one", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "select-one" },
     ];
@@ -54,7 +57,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldType should return checkbox if type is checkbox", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "checkbox" },
     ];
@@ -62,7 +64,6 @@ describe("FormTracker", () => {
   });
 
   test("getFieldType should return radio buttons if type is radio", () => {
-    const instance = new FormTracker();
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "radio" },
     ];
@@ -70,16 +71,14 @@ describe("FormTracker", () => {
   });
 
   test("getFieldLabel should return field label", () => {
-    const instance = new FormTracker();
     const label = document.createElement("label");
-    label.innerHTML = "test label";
     label.textContent = "test label";
     document.body.appendChild(label);
     expect(instance.getFieldLabel()).toBe("test label");
+    document.body.removeChild(label);
   });
 
   test("getSubmitUrl should return submit url", () => {
-    const instance = new FormTracker();
     const form = document.createElement("form");
     form.action = "/test-url";
     form.innerHTML =
@@ -89,7 +88,6 @@ describe("FormTracker", () => {
   });
 
   test("getSubmitUrl should return submit url with the query params also", () => {
-    const instance = new FormTracker();
     const form = document.createElement("form");
     form.action = "/test-url?edit=true";
     form.innerHTML =
@@ -98,5 +96,64 @@ describe("FormTracker", () => {
     expect(instance.getSubmitUrl(form)).toBe(
       "http://localhost/test-url?edit=true",
     );
+  });
+
+  test("getSectionValue should return label text if field is not within a fieldset ", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create label and set for attribute
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id;
+    label.textContent = "test label";
+    document.body.appendChild(label);
+
+    // Create input and set id attribute to the same as label for attribute
+
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(instance.getSectionValue(formField)).toBe("test label");
+  });
+  test("getSectionValue returns legend text when input is inside a fieldset with legend , i.e radio or checkbox ", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+    // Create fieldset and legend
+    const fieldset = document.createElement("fieldset");
+    const legend = document.createElement("legend");
+    legend.textContent = "test legend";
+    fieldset.appendChild(legend);
+
+    // Create input and append to fieldset
+    const input = document.createElement("input");
+    input.id = formField.id;
+    fieldset.appendChild(input);
+
+    // Append fieldset to the document body
+    document.body.appendChild(fieldset);
+    expect(instance.getSectionValue(formField)).toBe("test legend");
+  });
+  test("getSectionValue should return undefined if there is no label or legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create input and set id attribute to the same as label for attribute
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(instance.getSectionValue(formField)).toBe("undefined");
   });
 });

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -91,7 +91,6 @@ describe("FormTracker", () => {
     label.textContent = "test label";
     document.body.appendChild(label);
     expect(instance.getFieldLabel()).toBe("test label");
-    document.body.removeChild(label);
   });
 
   test("getSubmitUrl should return submit url", () => {

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -37,7 +37,13 @@ export class FormTracker extends BaseTracker {
         );
         // New: If the checkbox is part of a group, concatenate the current checkbox's value with the existing value of that group's checkbox
         if (checkboxInSameGroup) {
-          checkboxInSameGroup.value += `, ${element.value}`;
+          checkboxInSameGroup.value += `, ${
+            document.querySelector(`label[for="${element.id}"]`)?.textContent
+              ? document
+                  .querySelector(`label[for="${element.id}"]`)
+                  ?.textContent?.trim()
+              : "undefined"
+          }`;
         } else {
           selectedFields.push({
             id: element.id,

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -119,6 +119,36 @@ export class FormTracker extends BaseTracker {
     }
     return label;
   }
+  /**
+   * Get the section value from the label or legend associated with the HTML form element.
+   *
+   * @param {FormField[]} elements - The array of form fields.
+   * @return {string} The label or legend of the field.
+   */
+  getSectionValue(elements: FormField[]): string {
+    for (const element of elements) {
+      const field = document.getElementById(element.id);
+      const fieldset = field?.closest("fieldset");
+      if (fieldset) {
+        // If it's a child of a fieldset e.g radio button/ checkbox, look for the legend
+        const legendElement = fieldset.querySelector("legend");
+        if (legendElement && legendElement.textContent) {
+          return legendElement.textContent.trim();
+        }
+      } else {
+        // If not within a fieldset,e.g free text field, dropdown check for label
+        const labelElement = document.querySelector(
+          `label[for="${element.id}"]`,
+        );
+        if (labelElement && labelElement.textContent) {
+          return labelElement.textContent.trim();
+        }
+      }
+    }
+
+    // If not within a fieldset or no legend found, return an empty string
+    return "";
+  }
 
   /**
    * Get the submit URL from the given HTML form element.

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -122,32 +122,28 @@ export class FormTracker extends BaseTracker {
   /**
    * Get the section value from the label or legend associated with the HTML form element.
    *
-   * @param {FormField[]} elements - The array of form fields.
+   * @param {FormField} element - The form field.
    * @return {string} The label or legend of the field.
    */
-  getSectionValue(elements: FormField[]): string {
-    for (const element of elements) {
-      const field = document.getElementById(element.id);
-      const fieldset = field?.closest("fieldset");
-      if (fieldset) {
-        // If it's a child of a fieldset e.g radio button/ checkbox, look for the legend
-        const legendElement = fieldset.querySelector("legend");
-        if (legendElement && legendElement.textContent) {
-          return legendElement.textContent.trim();
-        }
-      } else {
-        // If not within a fieldset,e.g free text field, dropdown check for label
-        const labelElement = document.querySelector(
-          `label[for="${element.id}"]`,
-        );
-        if (labelElement && labelElement.textContent) {
-          return labelElement.textContent.trim();
-        }
+  getSectionValue(element: FormField): string {
+    const field = document.getElementById(element.id);
+    const fieldset = field?.closest("fieldset");
+    if (fieldset) {
+      // If it's a child of a fieldset e.g radio button/ checkbox, look for the legend
+      const legendElement = fieldset.querySelector("legend");
+      if (legendElement && legendElement.textContent) {
+        return legendElement.textContent.trim();
+      }
+    } else {
+      // If not within a fieldset,e.g free text field, dropdown check for label
+      const labelElement = document.querySelector(`label[for="${element.id}"]`);
+      if (labelElement && labelElement.textContent) {
+        return labelElement.textContent.trim();
       }
     }
 
     // If not within a fieldset or no legend found, return an empty string
-    return "";
+    return "undefined";
   }
 
   /**


### PR DESCRIPTION
### Description ###

1. **Iterative Event Generation:** Updated the trackFormResponse method to iterate through the array of FormField objects, generating events for each field individually rather than a singular event for the whole form 

2.  **New Utility Function - getSectionValue:**

Created a new utility function, getSectionValue, which the FormResponseTracker uses to retrieve the section value associated with each field.

- Section Value Determination:

Implemented checks in getSectionValue to determine the appropriate section value for each field.

If the field is within a` <fieldset>`, it retrieves the` <legend>` using a query selector and stores it in a string. This is targeted at radio and checkbox fields.
If the field has an associated label, it retrieves and stores the label in a string. This is targeted at text fields, text areas, and dropdown fields.

**Steps Involved:**

As the trackFormResponse iterates through the FormField array, the getSectionValue function is invoked for each field by passing it as a parameter (e.g., `getSectionValue([field])`).

The getSectionValue function checks whether the field is within a `<fieldset>` or has an associated label to determine the appropriate section value.

If the field is in a `<fieldset>`, it retrieves the `<legend>`; otherwise, it checks for an associated label.
The retrieved label or legend is then returned as the section value in a string.

Screenshots of HTML structure of GOV.UK form fields below to support my if logic ...

Radio and Checkboxes field are nested in a fieldset with a legend 
**Radio**
<img width="806" alt="Screenshot 2024-01-04 at 15 06 17" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/f502769f-a85c-4489-b42f-4bdbc6de0875">
**Checkboxes**
<img width="829" alt="Screenshot 2024-01-04 at 15 06 51" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/a87ddcb6-e533-4a75-8c04-939fe8360189">

Text Input, Textarea and Dropdown only have labels ...

**Text Input:**
<img width="743" alt="Screenshot 2024-01-04 at 15 09 39" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/fe927301-f0e9-464e-a804-a268136fa946">

**Dropdown:**
<img width="743" alt="Screenshot 2024-01-04 at 15 10 06" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/c77a4423-2b0d-4c1c-96b2-5001381718f8">
3. **Added unit tests** for getSectionValue
4. **Added unit test** to cover additional scenario added to the getFormFields function (when a checkbox part of checkbox group) .
5. **Added unit test** to test trackFormResponse when there is a form with multiple fields
6.  Updated the document.body.innerHTML in the test cases for radio buttons and checkboxes to include legend to accurately reflect the structure of GOV.UK components 
### Tickets ###
(DFC-186)[https://govukverify.atlassian.net/browse/DFC-186]

### Steps to Reproduce ###

Run npm test

### Co-Authored By ###


### Additional Information ###
