### PR TITLE
DFC-187 | Update error tracker to manage multiple fields

### DIFF
--- a/src/analytics/formErrorTracker/formErrorTracker.test.ts
+++ b/src/analytics/formErrorTracker/formErrorTracker.test.ts
@@ -47,11 +47,6 @@ describe("FormErrorTracker", () => {
       '  <select id="region" name="Region"><option value="test value">test value</option><option value="test value2" >test value2</option></select>' +
       "</div>" +
       '<div class="govuk-form-group govuk-form-group--error">' +
-      '  <p id="username-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
-      '  <label for="username">text input section</label>' +
-      '  <input type="text" id="username" name="Username" value="test value"/>' +
-      "</div>" +
-      '<div class="govuk-form-group govuk-form-group--error">' +
       "<fieldset>" +
       "  <legend>radio section</legend>" +
       '  <p id="male-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one radio option </p>' +
@@ -247,5 +242,78 @@ describe("FormErrorTracker", () => {
     input.id = formField.id;
     document.body.appendChild(input);
     expect(instance.getErrorMessage(formField)).toBe("undefined");
+  });
+  test("getErrorFields should return an array of the first field in each form group in a form that have an error message", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="questionType">checked value</label>' +
+      '  <p id="questionType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one checkbox</p>' +
+      '  <input type="checkbox" id="questionType" name="questionType" value="checkedValue" />' +
+      '  <label for="questionType-2">checked value2</label>' +
+      '  <input type="checkbox" id="questionType-2" name="questionType" value="checkedValue2" />' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="region">dropdown section</label>' +
+      '  <p id="region-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
+      '  <select id="region" name="Region"><option value="test value">test value</option><option value="test value2" >test value2</option></select>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <p id="male-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one radio option </p>' +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value"/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="feedback">textarea section</label>' +
+      '  <p id="feedback-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your feedback</p>' +
+      '  <textarea id="feedback" name="Feedback" /></textarea>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="email">text input section</label>' +
+      '  <p id="email-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your email</p>' +
+      '  <input type ="text" id="email" name="Email" /></input>' +
+      "</div>" +
+      '  <button id="button" type="submit">submit</button>';
+    document.body.appendChild(form);
+    expect(instance.getErrorFields(form)).toEqual([
+      {
+        id: "questionType",
+        name: "questionType",
+        value: "checkedValue",
+        type: "checkbox",
+      },
+      {
+        id: "region",
+        name: "Region",
+        value: "test value",
+        type: "select-one",
+      },
+      {
+        id: "male",
+        name: "radioGroup",
+        value: "radio value",
+        type: "radio",
+      },
+      {
+        id: "feedback",
+        name: "Feedback",
+        value: "",
+        type: "textarea",
+      },
+      {
+        id: "email",
+        name: "Email",
+        value: "",
+        type: "text",
+      },
+    ]);
   });
 });

--- a/src/analytics/formErrorTracker/formErrorTracker.test.ts
+++ b/src/analytics/formErrorTracker/formErrorTracker.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect, jest, test } from "@jest/globals";
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
 import { FormErrorTracker } from "./formErrorTracker";
-import { FormEventInterface } from "../formTracker/formTracker.interface";
+import {
+  FormEventInterface,
+  FormField,
+} from "../formTracker/formTracker.interface";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("FormErrorTracker", () => {
+  let instance: FormErrorTracker;
+
+  beforeEach(() => {
+    instance = new FormErrorTracker();
+    // Remove any existing elements from document.body if needed
+    document.body.innerHTML = "";
+  });
   const spy = jest.spyOn(FormErrorTracker.prototype, "pushToDataLayer");
   const trackFormErrorSpy = jest.spyOn(
     FormErrorTracker.prototype,
@@ -13,22 +23,170 @@ describe("FormErrorTracker", () => {
 
   test("trackFormError should return false if not cookie consent", () => {
     window.DI.analyticsGa4.cookie.consent = false;
-    const instance = new FormErrorTracker();
+
     instance.trackFormError();
     expect(instance.trackFormError).toReturnWith(false);
   });
-
-  test("datalayer event should be defined", () => {
+  test("form error tracker should define a DL for each field in form", () => {
     window.DI.analyticsGa4.cookie.consent = true;
-    const instance = new FormErrorTracker();
     document.body.innerHTML =
       '<form action="/test-url" method="post">' +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="questionType">checked value</label>' +
+      '  <p id="questionType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one checkbox</p>' +
+      '  <input type="checkbox" id="questionType" name="questionType" value="checkedValue" />' +
+      '  <label for="questionType-2">checked value2</label>' +
+      '  <input type="checkbox" id="questionType-2" name="questionType" value="checkedValue2" />' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="region">dropdown section</label>' +
+      '  <p id="region-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
+      '  <select id="region" name="Region"><option value="test value">test value</option><option value="test value2" >test value2</option></select>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <p id="username-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
+      '  <label for="username">text input section</label>' +
+      '  <input type="text" id="username" name="Username" value="test value"/>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <p id="male-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one radio option </p>' +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value"/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="feedback">textarea section</label>' +
+      '  <p id="feedback-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your feedback</p>' +
+      '  <textarea id="feedback" name="Feedback" /></textarea>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="email">text input section</label>' +
+      '  <p id="email-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your email</p>' +
+      '  <input type ="text" id="email" name="Email" /></input>' +
+      "</div>" +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>";
+
+    const dataLayerEventCheckbox: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "error: select one checkbox",
+        section: "checked section",
+        action: "error",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventDropdown: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "drop-down list",
+        url: "http://localhost/test-url",
+        text: "error: select one option from dropdown",
+        section: "dropdown section",
+        action: "error",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventRadio: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "error: select one radio option",
+        section: "radio section",
+        action: "error",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventTextarea: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "error: please give us your feedback",
+        section: "textarea section",
+        action: "error",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventText: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "error: please give us your email",
+        section: "text input section",
+        action: "error",
+        external: "undefined",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    instance.trackFormError();
+
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventDropdown);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventRadio);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventTextarea);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventText);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEventCheckbox);
+  });
+  test("datalayer event should be defined", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+
+    document.body.innerHTML =
+      '<form action="/test-url" method="post">' +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
       "  <legend>test label questions</legend>" +
       '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <label for="question-1">test label question 1</label>' +
-      '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
-      '  <label for="question-2">test label question 2</label>' +
-      '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
+      '  <label for="organisationType">test label question 1</label>' +
+      '  <input type="checkbox" id="organisationType" name="organisationType" value="test value" checked/>' +
+      '  <label for="organisationType-2">test label question 2</label>' +
+      '  <input type="checkbox" id="organisationType-2" name="organisationType2" value="test value"/>' +
+      "</fieldset>" +
+      "</div>" +
       '  <button id="button" type="submit">submit</button>' +
       "</form>";
 
@@ -56,96 +214,38 @@ describe("FormErrorTracker", () => {
   });
 
   test("getErrorMessage should return error message", () => {
-    const instance = new FormErrorTracker();
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      "  <legend>test label questions</legend>" +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <label for="question-1">test label question 1</label>' +
-      '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
-      '  <label for="question-2">test label question 2</label>' +
-      '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-    expect(instance.getErrorMessage()).toEqual("Error: Select one option");
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create error element
+    const errorElement = document.createElement("p");
+    errorElement.id = "fieldId-error";
+    errorElement.textContent = "error: this is an  error message";
+    document.body.appendChild(errorElement);
+    // Create input element
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(instance.getErrorMessage(formField)).toBe(
+      "error: this is an  error message",
+    );
   });
+  test("getErrorMessage should return undefined , when there is no error message", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
 
-  test("getType with checkbox field should return the type checkbox", () => {
-    const instance = new FormErrorTracker();
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      "  <legend>test label questions</legend>" +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <label for="question-1">test label question 1</label>' +
-      '  <input type="checkbox" id="question-1" name="question-1" value="test value" checked/>' +
-      '  <label for="question-2">test label question 2</label>' +
-      '  <input type="checkbox" id="question-2" name="question-2" value="test value"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-    const form = document.forms[0];
-    expect(instance.getType(form)).toEqual("checkbox");
-  });
-
-  test("getType with text field should return the type free text field", () => {
-    const instance = new FormErrorTracker();
-
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      '  <label for="username">test label username</label>' +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <input type="text" id="username" name="username" value="test value"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-
-    const form = document.forms[0];
-    expect(instance.getType(form)).toEqual("free text field");
-  });
-
-  test("getType with textarea field should return the type free text field", () => {
-    const instance = new FormErrorTracker();
-
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      '  <label for="username">test label username</label>' +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <textarea id="username" name="username" value="test value"/>test value</textarea>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-
-    const form = document.forms[0];
-    expect(instance.getType(form)).toEqual("free text field");
-  });
-
-  test("getType with select field should return the type dropdown-list", () => {
-    const instance = new FormErrorTracker();
-
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      '  <label for="username">test label username</label>' +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-
-    const form = document.forms[0];
-    expect(instance.getType(form)).toEqual("drop-down list");
-  });
-
-  test("getType with radio buttons field should return the type radio buttons", () => {
-    const instance = new FormErrorTracker();
-
-    document.body.innerHTML =
-      '<form action="/test-url" method="post">' +
-      "  <legend>test label questions</legend>" +
-      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
-      '  <label for="male">test label male</label>' +
-      '  <input type="radio" id="male" name="male" value="Male" checked/>' +
-      '  <label for="female">test label female</label>' +
-      '  <input type="radio" id="female" name="female" value="Male"/>' +
-      '  <button id="button" type="submit">submit</button>' +
-      "</form>";
-
-    const form = document.forms[0];
-    expect(instance.getType(form)).toEqual("radio buttons");
+    // Create input element
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(instance.getErrorMessage(formField)).toBe("undefined");
   });
 });

--- a/src/analytics/formErrorTracker/formErrorTracker.ts
+++ b/src/analytics/formErrorTracker/formErrorTracker.ts
@@ -27,7 +27,7 @@ export class FormErrorTracker extends FormTracker {
     let fields: FormField[] = [];
 
     if (form && form.elements) {
-      fields = this.getFieldsWithErrors(form);
+      fields = this.getErrorFields(form);
     } else {
       return false;
     }
@@ -67,6 +67,14 @@ export class FormErrorTracker extends FormTracker {
     }
   }
 
+  /**
+   Retrieve the text content of an error message associated with a specific form field.
+
+   * @param {FormField} field - The form field.
+   * @return returns a string representing the text content of the error message associated with the specified form field. 
+   * If no error message is found, it returns the string "undefined
+   */
+
   getErrorMessage(field: FormField) {
     const error = document.getElementById(`${field.id}-error`);
     if (error) {
@@ -76,7 +84,16 @@ export class FormErrorTracker extends FormTracker {
     }
   }
 
-  getFieldsWithErrors(form: HTMLFormElement): FormField[] {
+  /**
+   * Querys first input, textarea, or select element within each form group that has an error message.
+   * If element is found, creates a FormField object with information about the element
+   * (id, name, value, type) and pushes this FormField object into the errorFields array.
+
+   * @param {form: HTMLFormElement} - The HTML form element.
+   * @return {FormField[]} elements - The array containing information about form fields associated with errors..
+   */
+
+  getErrorFields(form: HTMLFormElement): FormField[] {
     const errorFields: FormField[] = [];
     const formGroups = document.querySelectorAll(".govuk-form-group--error");
 

--- a/src/analytics/formErrorTracker/formErrorTracker.ts
+++ b/src/analytics/formErrorTracker/formErrorTracker.ts
@@ -24,6 +24,7 @@ export class FormErrorTracker extends FormTracker {
     }
 
     const form = document.forms[0];
+    const submitUrl = this.getSubmitUrl(form);
     let fields: FormField[] = [];
 
     if (form && form.elements) {
@@ -38,7 +39,6 @@ export class FormErrorTracker extends FormTracker {
     }
     try {
       for (const field of fields) {
-        const submitUrl = this.getSubmitUrl(form);
         const formErrorTrackerEvent: FormEventInterface = {
           event: this.eventType,
           event_data: {

--- a/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -48,6 +48,7 @@ export class FormResponseTracker extends FormTracker {
     }
 
     const form = document.forms[0];
+    const submitUrl = this.getSubmitUrl(form);
     let fields: FormField[] = [];
 
     if (form && form.elements) {
@@ -64,8 +65,6 @@ export class FormResponseTracker extends FormTracker {
     try {
       // Iterate through each form field and generate an event for each
       for (const field of fields) {
-        const submitUrl = this.getSubmitUrl(form);
-
         const formResponseTrackerEvent: FormEventInterface = {
           event: this.eventType,
           event_data: {


### PR DESCRIPTION
### Description ###


Changes Made:

1. **trackFormError Update:**
- Iterated through fields in the form group.
- Pushed an event_data object for each field with an error message.

2. **getErrorFields Function Added:**
- Retrieves fields with only error messages.
- Ensures trackFormResponse only pushes event_data objects for fields with errors.

3. **Unit Tests Added:**
- Added tests for the new getErrorFields function.

4. **getErrorMessage Update:**
- Retrieves error message associated with a specific field.id.
- Ensures the correct error message is sent to DL.

5. **Unit Tests Added:**
- Tests for getErrorMessage to verify correct error message retrieval.
- Tests for the updated FormErrorTracker to handle multiple fields with error messages.

6. **Refactoring:**
- Removed getType function and its associated unit tests.


### Tickets ###
(DFC-187)[https://govukverify.atlassian.net/browse/DFC-187]

### Steps to Reproduce ###


### Co-Authored By ###


### Additional Information ###

