### PR TITLE
DFC-296: fix loadgtmscript bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/one-login-analytics",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Reusable GA4 package for GDS One Login",
   "main": "lib/analytics.js",
   "type": "module",

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -43,6 +43,10 @@ export class Analytics {
    * @return {boolean} Returns true if the script was successfully loaded and appended, otherwise false.
    */
   loadGtmScript(gtmId: string): boolean {
+    if (!gtmId) {
+      gtmId = this.gtmId;
+    }
+
     const googleSrc = "https://www.googletagmanager.com/gtm.js?id=" + gtmId;
     const newScript = document.createElement("script");
     newScript.async = true;


### PR DESCRIPTION
### Description ###
accept analytics tracking doesn't load correctly the gtm script

### Tickets ###
(DFC-296)[https://govukverify.atlassian.net/browse/DFC-296]

### Steps to Reproduce ###
User accepts analytics cooking tracking.
Result: GTM script is loaded without the gtmId

### Co-Authored By ###


### Additional Information ###

