### PR TITLE
DFC-291 | BUG | Navigation Tracker returns "license" as section value for licence link in footer

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -285,18 +285,18 @@ describe("getSection", () => {
     expect(newInstance.getSection(element)).toBe("support links");
   });
 
-  test("it should return license links when a link is clicked in the license link", () => {
+  test("it should return licence links when a link is clicked in the licence link", () => {
     const href = document.createElement("A");
     href.className = "govuk-link";
     href.dispatchEvent(action);
     document.body.innerHTML =
       "<span class='govuk-footer__licence-description'></span>";
-    const license = document.getElementsByClassName(
+    const licence = document.getElementsByClassName(
       "govuk-footer__licence-description",
     )[0];
-    license.appendChild(href);
+    licence.appendChild(href);
     const element = action.target as HTMLLinkElement;
-    expect(newInstance.getSection(element)).toBe("license");
+    expect(newInstance.getSection(element)).toBe("licence");
   });
 
   test("it should return copyright when a link is clicked on copyright image", () => {

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -149,7 +149,7 @@ export class NavigationTracker extends BaseTracker {
    * Returns the type of section based on the given HTML link element.
    *
    * @param {HTMLLinkElement} element - The HTML link element to get the type of.
-   * @return {string} The section: "logo", "phase banner", "menu links", "support links", "license", "copyright" or "undefined".
+   * @return {string} The section: "logo", "phase banner", "menu links", "support links", "licence", "copyright" or "undefined".
    */
   getSection(element: HTMLElement): string {
     // if header
@@ -161,8 +161,8 @@ export class NavigationTracker extends BaseTracker {
       return "menu links";
     } else if (this.isSupportLink(element)) {
       return "support links";
-    } else if (this.isLicenseLink(element)) {
-      return "license";
+    } else if (this.isLicenceLink(element)) {
+      return "licence";
     } else if (this.isCopyright(element)) {
       return "copyright";
     }
@@ -253,12 +253,12 @@ export class NavigationTracker extends BaseTracker {
   }
 
   /**
-   * Determines if the given class name is a license link
+   * Determines if the given class name is a licence link
    *
    * @param {string} element - The HTML link element to get the type of.
    * @return {boolean} Returns true if the class name of this element includes "govuk-footer__licence-description", false otherwise.
    */
-  isLicenseLink(element: HTMLElement): boolean {
+  isLicenceLink(element: HTMLElement): boolean {
     const supportLinks = document.getElementsByClassName(
       "govuk-footer__licence-description",
     )[0];
@@ -272,9 +272,9 @@ export class NavigationTracker extends BaseTracker {
    * @return {boolean} Returns true if the class name of this element includes "govuk-footer__copyright-logo", false otherwise.
    */
   isCopyright(element: HTMLElement): boolean {
-    const licenseLinks = document.getElementsByClassName(
+    const licenceLinks = document.getElementsByClassName(
       "govuk-footer__copyright-logo",
     )[0];
-    return licenseLinks && licenseLinks.contains(element);
+    return licenceLinks && licenceLinks.contains(element);
   }
 }


### PR DESCRIPTION
Changed all instances of "license" to "licence" for NavigationTracker