### PR TITLE
DFC - 297 | BUG | Form Response & Error Tracker | getSectionValue Function

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -171,6 +171,28 @@ Trigger by the submission of any form, this tracker will send to GA4 some data a
 - Submit Button text
 - Value of the field
 
+### Checkbox or Radio Fields Without a Legend
+
+If a checkbox or radio field has been implemented without a legend, please follow these steps to ensure the tracker can retrieve the correct section value:
+
+1. Add a `rel` attribute to the tag used to hold the section title.
+2. Set the `rel` attribute value to match the `id` of the field.
+
+**Example:**
+(
+
+<h2 rel="consentCheckbox">Section Title</h2>
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input id="consentCheckbox" name="consentCheckbox" type="checkbox" />
+      <label id="consentCheckbox-label" for="consentCheckbox">
+        Checkbox Label
+      </label>
+    </div>
+  </div>
+</div>)
+
 ### Form Change Tracker
 
 Form Change Tracker is triggered when a user clicks on a link that allows them to change a previous form they had completed and loads the form page correctly. The URL needs to contain an edit parameter equal to true (example: /my-form-page?edit=true).
@@ -181,8 +203,31 @@ We are tracking the label of the field and the submit button text.
 Form Error Tracker is triggered when a page loads and when the page displays any form errors.
 We are tracking the label of the field and the error message.
 
+### Checkbox or Radio Fields Without a Legend
+
+If a checkbox or radio field has been implemented without a legend, please follow these steps to ensure the tracker can retrieve the correct section value:
+
+1. Add a `rel` attribute to the tag used to hold the section title.
+2. Set the `rel` attribute value to match the `id` of the field.
+
+**Example:**
+(
+
+<h2 rel="consentCheckbox">Section Title</h2>
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input id="consentCheckbox" name="consentCheckbox" type="checkbox" />
+      <label id="consentCheckbox-label" for="consentCheckbox">
+        Checkbox Label
+      </label>
+    </div>
+  </div>
+</div>)
+
 ### Universal Analytics compability
 
-More information: https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3843227661/Universal+Analytics+compatibility
+More information:
+https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3843227661/Universal+Analytics+compatibility
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -128,19 +128,19 @@ describe("FormTracker", () => {
     label.textContent = "test label";
     document.body.appendChild(label);
 
-    // Create input and set id attribute to the same as label for attribute
+    // Create input and set ID attribute to the same as label FOR attribute
 
     const input = document.createElement("input");
     input.id = formField.id;
     document.body.appendChild(input);
     expect(instance.getSectionValue(formField)).toBe("test label");
   });
-  test("getSectionValue returns legend text when input is inside a fieldset with legend , i.e radio or checkbox ", () => {
+  test("getSectionValue returns legend text when input is inside a fieldset with legend , i.e radio", () => {
     const formField: FormField = {
       id: "fieldId",
       name: "fieldName",
       value: "fieldValue",
-      type: "text",
+      type: "radio buttons",
     };
     // Create fieldset and legend
     const fieldset = document.createElement("fieldset");
@@ -148,8 +148,9 @@ describe("FormTracker", () => {
     legend.textContent = "test legend";
     fieldset.appendChild(legend);
 
-    // Create input and append to fieldset
+    // Create radio and append to fieldset
     const input = document.createElement("input");
+    input.type = "radio buttons";
     input.id = formField.id;
     fieldset.appendChild(input);
 
@@ -165,10 +166,167 @@ describe("FormTracker", () => {
       type: "text",
     };
 
-    // Create input and set id attribute to the same as label for attribute
+    // Create input and set ID attribute to the same as label FOR attribute
     const input = document.createElement("input");
     input.id = formField.id;
     document.body.appendChild(input);
     expect(instance.getSectionValue(formField)).toBe("undefined");
+  });
+  test("getSectionValue should return h1 with rel attribute matching element.id if there is a radio button without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio buttons",
+    };
+
+    // Create radio and set ID attribute to the same as label FOR attribute
+    const radio = document.createElement("input");
+    radio.type = "radio buttons";
+    radio.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the radio by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the radio and label to the document
+    document.body.appendChild(radio);
+    document.body.appendChild(label);
+    const h1 = document.createElement("h1");
+    h1.textContent = "Hello, World!";
+    h1.setAttribute("rel", formField.id);
+    document.body.appendChild(h1);
+    expect(instance.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return h2 with rel attribute matching element.id if there is a checkbox without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.textContent = "Hello, World!";
+    h2.setAttribute("rel", formField.id);
+    document.body.appendChild(h2);
+    expect(instance.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return first h1, if there is a checkbox without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h1 = document.createElement("h1");
+    h1.textContent = "Hello, World!";
+    document.body.appendChild(h1);
+    const secondh1 = document.createElement("h1");
+    secondh1.textContent = "Bye, World!";
+    document.body.appendChild(secondh1);
+    expect(instance.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return the FIRST h2 if there is a checkbox with a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.textContent = "Hello, World!";
+    document.body.appendChild(h2);
+    const secondh2 = document.createElement("h2");
+    secondh2.textContent = "Bye, World!";
+    document.body.appendChild(secondh2);
+    expect(instance.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return the FIRST h2 when there are radio buttons without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio buttons",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const radio = document.createElement("input");
+    radio.type = "radio buttons";
+    radio.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the radio buttons and label to the document
+    document.body.appendChild(radio);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.setAttribute("rel", formField.id);
+    h2.textContent = "Hello, World!";
+    document.body.appendChild(h2);
+    expect(instance.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return label when there is a dropdown with a label", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "dropdown",
+    };
+
+    // Create dropdown and set ID attribute to the same as label FOR attribute
+    const dropdown = document.createElement("input");
+    dropdown.type = "dropdown";
+    dropdown.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the dropdown by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the dropdown and label to the document
+    document.body.appendChild(dropdown);
+    document.body.appendChild(label);
+
+    expect(instance.getSectionValue(formField)).toBe("Your Label Text");
   });
 });

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -154,21 +154,44 @@ export class FormTracker extends BaseTracker {
   getSectionValue(element: FormField): string {
     const field = document.getElementById(element.id);
     const fieldset = field?.closest("fieldset");
+    const checkbox = element.type === "checkbox";
+    const radio = element.type === "radio buttons";
     if (fieldset) {
       // If it's a child of a fieldset e.g radio button/ checkbox, look for the legend
       const legendElement = fieldset.querySelector("legend");
       if (legendElement && legendElement.textContent) {
         return legendElement.textContent.trim();
       }
+      // if it is a checkbox or radio which does not have a legend, then check for the below conditions
+    } else if (checkbox || radio) {
+      // Look for h1 or h2 with rel attribute matching element.id
+      const h1OrH2WithRel = document.querySelector(
+        `h1[rel="${element.id}"], h2[rel="${element.id}"]`,
+      );
+      if (h1OrH2WithRel && h1OrH2WithRel.textContent) {
+        return h1OrH2WithRel.textContent.trim();
+      }
+
+      // If not found, get text content of the first h1
+      const firstH1 = document.querySelector("h1");
+      if (firstH1 && firstH1.textContent) {
+        return firstH1.textContent.trim();
+      }
+
+      // If not found, get text content of the first h2
+      const firstH2 = document.querySelector("h2");
+      if (firstH2 && firstH2.textContent) {
+        return firstH2.textContent.trim();
+      }
     } else {
-      // If not within a fieldset,e.g free text field, dropdown check for label
+      // If not within a fieldset and not a checkbox or radio button then,e.g free text field, dropdown check for label
       const labelElement = document.querySelector(`label[for="${element.id}"]`);
       if (labelElement && labelElement.textContent) {
         return labelElement.textContent.trim();
       }
     }
 
-    // If not within a fieldset or no legend found, return a "undefined" string
+    // If not within a fieldset or no legend or label found or no h1/h2 with rel attribute or no h1 or h2 then, return a "undefined" string
     return "undefined";
   }
 


### PR DESCRIPTION
### What 

Upon GA4 implementation on the Lime Pod's repos , it was discovered that due to the non-standard approach of implementing radio and checkbox forms, the formResponse and formError trackers were unable to retrieve the correct section values. Therefore updates to the getSectionValue function to expand its scope, so that : 

If a checkbox or radio form does not have a legend, the getSectionValue will look for a :

- `<h1> </h1>`  or `<h2> </h2>`with a rel attribute OR
- first` <h1> </h1>` on the page OR
- first `<h2> </h2>` on the page 
- Added the unit test for updated function
- updated package README with steps for implementation

### Why ?

In the ipv-cri-dl-front repo , they have a checkbox with no legend and have used a `<h2> </h2> ` as the tag to hold their section title, so I added a REL attribute to the h2 with the same value as the ID (rel = consentCheckbox) for the checkbox items .

<img width="1510" alt="Screenshot 2024-01-29 at 11 51 34" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/d08d4c66-850f-454e-88d6-9105defea70e">

### However 

Currently this is still retuning undefined for this radio form as there is no legend and the h1 holding the section title is outside of the form , so the trackers are unable to access.

ipv-cri-dl-front  / license-issuer page

<img width="1512" alt="Screenshot 2024-01-29 at 11 49 18" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/263d4ad4-27b9-482b-9977-14836c0ad0aa">

**Point to note :** Also if there is both a h1 or h2 on the page with no REL attribute it will just get the first h1 page even if the h2 holds the correct section value.

### Tickets

(DFC-297)[https://govukverify.atlassian.net/browse/DFC-297]
(DFC-298)[https://govukverify.atlassian.net/browse/DFC-298]


