### PR TITLE
DFC-431: add and remove class instead to change inline style

### DIFF
--- a/src/cookie/cookie.test.ts
+++ b/src/cookie/cookie.test.ts
@@ -153,7 +153,7 @@ describe("hideElement", () => {
     const instance = new Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.hideElement(element);
-    expect(element.classList).toContain(instance.HIDDING_CLASS);
+    expect(element.classList).toContain(instance.HIDDEN_CLASS);
   });
 });
 
@@ -162,7 +162,7 @@ describe("showElement", () => {
     const instance = new Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.showElement(element);
-    expect(element.classList).toContain(instance.SHOWING_CLASS);
+    expect(element.classList).toContain(instance.SHOWN_CLASS);
   });
 });
 

--- a/src/cookie/cookie.test.ts
+++ b/src/cookie/cookie.test.ts
@@ -153,7 +153,7 @@ describe("hideElement", () => {
     const instance = new Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.hideElement(element);
-    expect(element.style.display).toBe("none");
+    expect(element.classList).toContain(instance.HIDDING_CLASS);
   });
 });
 
@@ -162,7 +162,7 @@ describe("showElement", () => {
     const instance = new Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.showElement(element);
-    expect(element.style.display).toBe("block");
+    expect(element.classList).toContain(instance.SHOWING_CLASS);
   });
 });
 

--- a/src/cookie/cookie.ts
+++ b/src/cookie/cookie.ts
@@ -13,8 +13,8 @@ export class Cookie {
   public rejectCookies = document.getElementsByName("cookiesReject");
   cookieDomain: string;
 
-  HIDDING_CLASS = "govuk-!-display-none";
-  SHOWING_CLASS = "govuk-!-display-block";
+  HIDDEN_CLASS = "govuk-!-display-none";
+  SHOWN_CLASS = "govuk-!-display-block";
 
   constructor(cookieDomain: string | undefined) {
     this.initialise();
@@ -198,11 +198,11 @@ export class Cookie {
    * @param {HTMLElement} element - The HTML element to be hidden.
    */
   hideElement(element: HTMLElement): void {
-    if (!element?.classList.contains(this.HIDDING_CLASS)) {
-      element?.classList.add(this.HIDDING_CLASS);
+    if (!element?.classList.contains(this.HIDDEN_CLASS)) {
+      element?.classList.add(this.HIDDEN_CLASS);
     }
-    if (element?.classList.contains(this.SHOWING_CLASS)) {
-      element?.classList.remove(this.SHOWING_CLASS);
+    if (element?.classList.contains(this.SHOWN_CLASS)) {
+      element?.classList.remove(this.SHOWN_CLASS);
     }
   }
 
@@ -212,11 +212,11 @@ export class Cookie {
    * @param {HTMLElement} element - The element to be shown.
    */
   showElement(element: HTMLElement): void {
-    if (element?.classList.contains(this.HIDDING_CLASS)) {
-      element?.classList.remove(this.HIDDING_CLASS);
+    if (element?.classList.contains(this.HIDDEN_CLASS)) {
+      element?.classList.remove(this.HIDDEN_CLASS);
     }
-    if (!element?.classList.contains(this.SHOWING_CLASS)) {
-      element?.classList.add(this.SHOWING_CLASS);
+    if (!element?.classList.contains(this.SHOWN_CLASS)) {
+      element?.classList.add(this.SHOWN_CLASS);
     }
   }
 }

--- a/src/cookie/cookie.ts
+++ b/src/cookie/cookie.ts
@@ -13,6 +13,9 @@ export class Cookie {
   public rejectCookies = document.getElementsByName("cookiesReject");
   cookieDomain: string;
 
+  HIDDING_CLASS = "govuk-!-display-none";
+  SHOWING_CLASS = "govuk-!-display-block";
+
   constructor(cookieDomain: string | undefined) {
     this.initialise();
     this.cookieDomain = cookieDomain || "account.gov.uk";
@@ -45,6 +48,7 @@ export class Cookie {
           this.handleHideButtonClickEvent.bind(this),
         );
       }
+      this.showElement(this.cookieBannerContainer[0] as HTMLElement);
     }
   }
 
@@ -194,8 +198,11 @@ export class Cookie {
    * @param {HTMLElement} element - The HTML element to be hidden.
    */
   hideElement(element: HTMLElement): void {
-    if (element?.style) {
-      element.style.display = "none";
+    if (!element?.classList.contains(this.HIDDING_CLASS)) {
+      element?.classList.add(this.HIDDING_CLASS);
+    }
+    if (element?.classList.contains(this.SHOWING_CLASS)) {
+      element?.classList.remove(this.SHOWING_CLASS);
     }
   }
 
@@ -205,8 +212,11 @@ export class Cookie {
    * @param {HTMLElement} element - The element to be shown.
    */
   showElement(element: HTMLElement): void {
-    if (element?.style) {
-      element.style.display = "block";
+    if (element?.classList.contains(this.HIDDING_CLASS)) {
+      element?.classList.remove(this.HIDDING_CLASS);
+    }
+    if (!element?.classList.contains(this.SHOWING_CLASS)) {
+      element?.classList.add(this.SHOWING_CLASS);
     }
   }
 }

--- a/src/utils/validateParameter.ts
+++ b/src/utils/validateParameter.ts
@@ -10,14 +10,8 @@ export function validateParameter(parameter: any, maxLength: number) {
   const type = typeof parameter;
 
   if (type !== "string") {
-    console.error(
-      `GA4: Invalid data type found, ${parameter} should be a string but instead found a ${type}`,
-    );
     validatedParameter = "undefined";
   } else if (length > maxLength) {
-    console.error(
-      `GA4: ${parameter} should not be more than ${maxLength} characters, it is currently ${length} characters long`,
-    );
     validatedParameter = parameter.substring(0, maxLength);
   }
   const value = validatedParameter.toLowerCase();


### PR DESCRIPTION
Following discussion with (Boris Frontend Developer | SSE), inline style change creates a security issue. And some frontend repos don’t allow it.

So we need to change its:

add this instead: "govuk-!-display-none" when we want to hide it
remove  "govuk-!-display-none" (if needed) and add another govuk display class when we want to show.