### PR TITLE
DFC-414: getLoggedInStatus - add "undefined" condition

### DIFF
--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -66,6 +66,11 @@ describe("pageViewTracker", () => {
     expect(status).toBe("logged out");
   });
 
+  test("getLoggedInStatus returns the good data if loggedinstatus is undefined", () => {
+    const status = newInstance.getLoggedInStatus(undefined);
+    expect(status).toBe("undefined");
+  });
+
   test("getRelyingParty returns the good data", () => {
     const relyingParty = newInstance.getRelyingParty();
     expect(relyingParty).toBe("localhost");

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -82,7 +82,11 @@ export class PageViewTracker extends BaseTracker {
    * @param {boolean} loggedInStatus - The logged in status.
    * @return {string} The string representation of the logged in status.
    */
-  getLoggedInStatus(loggedInStatus: boolean): string {
+  getLoggedInStatus(loggedInStatus: boolean | undefined): string {
+    if (loggedInStatus === undefined) {
+      return "undefined";
+    }
+
     return loggedInStatus ? "logged in" : "logged out";
   }
 


### PR DESCRIPTION
getLoggedInStatus needs to return one of the 3 values: logged in, logged out, or undefined