### PR TITLE
DFC-509: Add internal url into navigation tracker

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -197,6 +197,11 @@ describe("isExternalLink", () => {
     expect(newInstance.isExternalLink(url)).toBe(false);
   });
 
+  test("should return false for signin account links", () => {
+    const url = "http://signin.account.gov.uk/cookies";
+    expect(newInstance.isExternalLink(url)).toBe(false);
+  });
+
   test("should return true for external links", () => {
     const url = "https://google.com";
     expect(newInstance.isExternalLink(url)).toBe(true);

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -128,11 +128,15 @@ export class NavigationTracker extends BaseTracker {
    * @return {boolean} Returns true if the URL is an external link, false otherwise.
    */
   isExternalLink(url: string): boolean {
+    const signinAccountUkUrl = "signin.account.gov.uk";
     if (!url) {
       return false;
     }
 
-    if (url.includes(window.location.hostname)) {
+    if (
+      url.includes(window.location.hostname) ||
+      url.includes(signinAccountUkUrl)
+    ) {
       return false;
     }
     return true;


### PR DESCRIPTION
Following Sam Evatt's comment (see jira ticket https://govukverify.atlassian.net/browse/DFC-509), I added an internal url which set the value of external to false.