### PR TITLE
[DFC-550] - Rename one-login-analytics to frontend-analytics

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -6,7 +6,7 @@
 <br />
 <div align="center">
   
-<h3 align="center">GOV UK One Login GA4 Implementation</h3>
+<h3 align="center">GOV.UK One Login GA4 Implementation</h3>
   <p align="center">
     This package enables GOV UK LOGIN frontend Node.js applications to use Google Tag Manager and Google Analytics 4.
     <br />
@@ -41,11 +41,11 @@
 
 ## About The Project
 
-The GDS One Login GA4 (Google Analytics 4) node package is a shared, reusable solution created to facilitate the upgrade from GAU to GA4 across the One Login programme as GAU is being retired mid 2024.
+The GDS Frontend Analytics (Google Analytics 4) node package is a shared, reusable solution created to facilitate the upgrade from GAU to GA4 across the GOV.UK One Login programme as GAU is being retired mid 2024.
 
-The purpose of this package is to make it as easy as possible for the various pods that make up the One Login journey to upgrade their analytics while having as minimal an impact as possible on the dev teams time and effort.
+The purpose of this package is to make it as easy as possible for the various pods that make up the GOV.UK One Login journey to upgrade their analytics while having as minimal an impact as possible on the dev teams time and effort.
 
-The package is owned by the DI Frontend Capability team, part of the development of this tool involves ongoing discovery with the pods responsible for maintaining the frontend repositories that make up the One Login journey. As more information is collated, the package and documentation will be updated. As such, it is considered a WIP and the pods will be notified when a stable release is ready.
+The package is owned by the DI Frontend Capability team, part of the development of this tool involves ongoing discovery with the pods responsible for maintaining the frontend repositories that make up the GOV.UK One Login journey. As more information is collated, the package and documentation will be updated. As such, it is considered a WIP and the pods will be notified when a stable release is ready.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -57,7 +57,7 @@ The package is owned by the DI Frontend Capability team, part of the development
 
 1. Install NPM package
    ```sh
-   npm install @govuk-one-login/one-login-analytics
+   npm install @govuk-one-login/frontend-analytics
    ```
 2. Configure your node application's startup file (example: app.js or index.js) and add a new virtual directory:
 
@@ -67,7 +67,7 @@ The package is owned by the DI Frontend Capability team, part of the development
      express.static(
        path.join(
          __dirname,
-         "../node_modules/@govuk-one-login/one-login-analytics/lib",
+         "../node_modules/@govuk-one-login/frontend-analytics/lib",
        ),
      ),
    );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/frontend-analytics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/frontend-analytics",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@govuk-one-login/one-login-analytics",
+  "name": "@govuk-one-login/frontend-analytics",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@govuk-one-login/one-login-analytics",
+      "name": "@govuk-one-login/frontend-analytics",
       "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@govuk-one-login/one-login-analytics",
+  "name": "@govuk-one-login/frontend-analytics",
   "version": "1.0.2",
   "description": "Reusable GA4 package for GDS One Login",
   "main": "lib/analytics.js",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "lib"
   ],
   "keywords": [
-    "one-login",
+    "govuk-one-login",
     "gds",
     "ga4",
     "google analytics 4",
-    "onelogin",
-    "one login"
+    "govukonelogin",
+    "gouk one login"
   ],
   "author": "DI Frontend Capability Team",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/frontend-analytics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Reusable GA4 package for GDS One Login",
   "main": "lib/analytics.js",
   "type": "module",


### PR DESCRIPTION
## Description

Renames the `@govuk-one-login/one-login-analytics` package to `@govuk-one-login/frontend-analytics` in compliance with naming requirements

Release v1.0.3

## Tickets
https://govukverify.atlassian.net/browse/DFC-550

