### PR TITLE
DAC-3541 | Refactor isHeaderMenuBarLink function 

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -217,8 +217,14 @@ describe("isHeaderMenuBarLink", () => {
     expect(newInstance.isHeaderMenuBarLink(element)).toBe(true);
   });
 
-  test("should return false if link is not inside the header tag", () => {
-    document.body.innerHTML = `<header></header><a id="testLink">Link to GOV.UK</a>`;
+  test("should return true if link is inside the nav tag", () => {
+    document.body.innerHTML = `<nav><a id="testLink">Link to GOV.UK</a></nav>`;
+    const element = document.getElementById("testLink") as HTMLElement;
+    expect(newInstance.isHeaderMenuBarLink(element)).toBe(true);
+  });
+
+  test("should return false if link is not inside the header or nav tag", () => {
+    document.body.innerHTML = `<div><a id="testLink">Link to GOV.UK</a></div>`;
     const element = document.getElementById("testLink") as HTMLElement;
     expect(newInstance.isHeaderMenuBarLink(element)).toBe(false);
   });

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -221,11 +221,11 @@ export class NavigationTracker extends BaseTracker {
    * Determines if the given element is a header link
    *
    * @param {string} element - The HTML link element to get the type of.
-   * @return {boolean} Returns true if the header tag contains this element, false otherwise.
+   * @return {boolean} Returns true if the header or nav tag contains this element, false otherwise.
    */
   isHeaderMenuBarLink(element: HTMLElement): boolean {
-    const header = document.getElementsByTagName("header")[0];
-    const nav = document.getElementsByTagName("nav")[0];
+    const header = document.querySelector("header");
+    const nav = document.querySelector("nav");
 
     if (header && header.contains(element)) {
       return true;

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -227,9 +227,15 @@ export class NavigationTracker extends BaseTracker {
     const header = document.getElementsByTagName("header")[0];
     const nav = document.getElementsByTagName("nav")[0];
 
-    return (
-      (header && header.contains(element)) || (nav && nav.contains(element))
-    );
+    if (header && header.contains(element)) {
+      return true;
+    }
+
+    if (nav && nav.contains(element)) {
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -227,15 +227,7 @@ export class NavigationTracker extends BaseTracker {
     const header = document.querySelector("header");
     const nav = document.querySelector("nav");
 
-    if (header && header.contains(element)) {
-      return true;
-    }
-
-    if (nav && nav.contains(element)) {
-      return true;
-    }
-
-    return false;
+    return header?.contains(element) || nav?.contains(element) || false;
   }
 
   /**

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -225,7 +225,11 @@ export class NavigationTracker extends BaseTracker {
    */
   isHeaderMenuBarLink(element: HTMLElement): boolean {
     const header = document.getElementsByTagName("header")[0];
-    return header && header.contains(element);
+    const nav = document.getElementsByTagName("nav")[0];
+
+    return (
+      (header && header.contains(element)) || (nav && nav.contains(element))
+    );
   }
 
   /**


### PR DESCRIPTION

### Description

Refactor the `isHeaderMenuBarLink` function to check if the element is contained within the first header or nav element. QA testing on the Home GA4 implementation highlighted an issue with tracking submenu items, where the parameter type is showing `generic link` instead of `header menu bar`. Currently, the function we use to determine if it is a HeaderMenuBar only checks the first header tag on the page, which is insufficient. As they already have a header element on the page, I have added a check for the first nav tag on the page. In the Home repo and Demo app, submenu links are located within nav tags.


### Tickets

(DAC-3541)[https://govukverify.atlassian.net/browse/DAC-3541]

### Steps to Reproduce

1. Run `npm run build`.
2. Copy the contents of the analytics.js file
3. Navigate to the [di-account-management-frontend repo](https://github.com/govuk-one-login/di-account-management-frontend).
4. Paste the contents of the analytics.js file into node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js.
5. Run `npm run build`.
6. Run the repo locally.
7. Test using the [Google Tag Assistant](https://tagassistant.google.com/#/?source=TAG_MANAGER&id=GTM-KD86CMZ&gtm_auth=2xLisdJc9pojWlZ4awSAiQ&gtm_preview=env-3&cb=1511317486935599).
8. Check the Data Layer Push.

### Co-Authored By

### Checklist

[ ] - Are the commit messages for this PR in line with the GDS way?
[ ] - Have the changes in this PR been tested locally (if required)
[ ] - Have additional tests been added where required?
[ ] - Does the feature pass accessibility checks? (UI Components only)

### Additional Information

Home Repo  UI / HTML

<img width="919" alt="Screenshot 2024-06-19 at 14 16 16" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/98d41851-59e4-4e55-adfb-b3470f0871c4">

Demo App Repo  UI / HTML

<img width="913" alt="Screenshot 2024-06-19 at 14 17 09" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/8fd65cab-faad-4b5c-96e7-dc94e6d086b2">

