### PR TITLE
Bugfix:  Add missing events to initialise the Google Tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/frontend-analytics",
-  "version": "1.0.3",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/frontend-analytics",
-      "version": "1.0.3",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "copy-webpack-plugin": "^12.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/frontend-analytics",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reusable GA4 package for GDS One Login",
   "main": "lib/analytics.js",
   "type": "module",

--- a/src/analytics/baseTracker/baseTracker.ts
+++ b/src/analytics/baseTracker/baseTracker.ts
@@ -1,6 +1,7 @@
 import { PageViewEventInterface } from "../pageViewTracker/pageViewTracker.interface";
 import { NavigationEventInterface } from "../navigationTracker/navigationTracker.interface";
 import { FormEventInterface } from "../formTracker/formTracker.interface";
+import { GTMInitInterface } from "../pageViewTracker/pageViewTracker.interface";
 
 declare global {
   interface Window {
@@ -23,7 +24,8 @@ export class BaseTracker {
     event:
       | PageViewEventInterface
       | NavigationEventInterface
-      | FormEventInterface,
+      | FormEventInterface
+      | GTMInitInterface,
   ): boolean {
     window.dataLayer = window.dataLayer || [];
     try {

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -29,6 +29,12 @@ export class Analytics {
     });
 
     if (!options.disableGa4Tracking) {
+      this.pageViewTracker.pushToDataLayer({
+        "gtm.allowlist": ["google"],
+        "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
+        "gtm.start": new Date().getTime(),
+        event: "gtm.js",
+      });
       this.formResponseTracker = new FormResponseTracker(this.isDataSensitive);
       this.navigationTracker = new NavigationTracker();
       if (this.cookie.consent) {

--- a/src/analytics/pageViewTracker/pageViewTracker.interface.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.interface.ts
@@ -17,6 +17,7 @@ export interface PageViewEventInterface {
     updated_at?: string;
     relying_party?: string;
   };
+  // "gtm.allowlist": string[];
 }
 
 export interface PageViewParametersInterface {
@@ -27,4 +28,11 @@ export interface PageViewParametersInterface {
   content_id: string;
   logged_in_status: boolean;
   dynamic: boolean;
+}
+
+export interface GTMInitInterface {
+  event: string;
+  "gtm.allowlist": string[];
+  "gtm.blocklist": string[];
+  "gtm.start": number;
 }


### PR DESCRIPTION
### Description

As a result of building the GA solution as an extension of existing functionality, some required initialisation events were missed and not discovered due to UA running in parallel during the QA process.

New events are now fired when the Analytics package is initialised as part of core functionality, allowing us to confirm events coming from the google tag

### Tickets

[DFC-\*\*](https://govukverify.atlassian.net/browse/DFC-**)

### Steps to Reproduce

- Disable UA in test repository
- Build analytics dist folder
- Copy output of second command into the node_modules folder of the target repository, replacing the existing analytics.js file
- Build frontend as normal, open localhost via tag assistant
- Cause some GA events to fire, then in the tag assistant check the `G-MHX9DPZ660` tag for 'Hits'
- The same events in the container should be in the tag:

<img width="788" alt="image" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148477198/affcc736-bd91-47a1-942d-112b10dbf6d2">

### Co-Authored By

@nickhealGDS 

### Checklist

[x] - Are the commit messages for this PR in line with the GDS way?
[x] - Have the changes in this PR been tested locally (if required)
[ ] - Have additional tests been added where required?
