### PR TITLE
DAC-3613 - Update trigger and tests for formChangeTracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm ci && npm run prettier && webpack --config webpack.config.js --mode production",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
-    "precommit": "npm run prettier && git add .",
+    "precommit": "npm run prettier",
     "pub": "cp PACKAGE-README.md dist/README.md && cp package.json dist && cd dist && npm publish --access public",
     "test": "jest",
     "test:coverage": "jest --coverage src"

--- a/src/analytics/baseTracker/baseTracker.test.ts
+++ b/src/analytics/baseTracker/baseTracker.test.ts
@@ -100,7 +100,7 @@ describe("should return the good parameter values", () => {
 
 describe("should check for changeLink", () => {
   const newInstance = new BaseTracker();
-  test("should return true if element is not a change link", () => {
+  test("should return true if element is a change link", () => {
     const href = document.createElement("a");
     href.setAttribute("href", "http://localhost?edit=true");
     expect(newInstance.isChangeLink(href)).toBe(true);

--- a/src/analytics/baseTracker/baseTracker.test.ts
+++ b/src/analytics/baseTracker/baseTracker.test.ts
@@ -97,3 +97,17 @@ describe("should return the good parameter values", () => {
     expect(location).toEqual("undefined");
   });
 });
+
+describe("should check for changeLink", () => {
+  const newInstance = new BaseTracker();
+  test("should return true if element is not a change link", () => {
+    const href = document.createElement("a");
+    href.setAttribute("href", "http://localhost?edit=true");
+    expect(newInstance.isChangeLink(href)).toBe(true);
+  });
+  test("should return false if element is not a change link", () => {
+    const href = document.createElement("a");
+    href.setAttribute("href", "http://localhost");
+    expect(newInstance.isChangeLink(href)).toBe(false);
+  });
+});

--- a/src/analytics/baseTracker/baseTracker.ts
+++ b/src/analytics/baseTracker/baseTracker.ts
@@ -84,4 +84,13 @@ export class BaseTracker {
     const domainPath = newUrl.pathname.substring(start, end);
     return domainPath.length ? domainPath : "undefined";
   }
+
+  //check for change links used by both navigationTracker and formChangeTracker
+  isChangeLink(element: HTMLElement): boolean {
+    if (element.tagName === "A") {
+      let anchorElement = element as HTMLAnchorElement;
+      return new URL(anchorElement.href).searchParams.get("edit") === "true";
+    }
+    return false;
+  }
 }

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -1,4 +1,5 @@
 import { Cookie } from "../../cookie/cookie";
+import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
 import { FormResponseTracker } from "../formResponseTracker/formResponseTracker";
 import { NavigationTracker } from "../navigationTracker/navigationTracker";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
@@ -10,6 +11,7 @@ export class Analytics {
   uaContainerId: string | undefined;
   pageViewTracker: PageViewTracker | undefined;
   navigationTracker: NavigationTracker | undefined;
+  formChangeTracker: FormChangeTracker | undefined;
   cookie: Cookie | undefined;
   formResponseTracker: FormResponseTracker | undefined;
 
@@ -31,6 +33,7 @@ export class Analytics {
     if (!options.disableGa4Tracking) {
       this.formResponseTracker = new FormResponseTracker(this.isDataSensitive);
       this.navigationTracker = new NavigationTracker();
+      this.formChangeTracker = new FormChangeTracker();
       if (this.cookie.consent) {
         this.loadGtmScript(this.gtmId);
       }

--- a/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -38,23 +38,14 @@ describe("FormChangeTracker", () => {
 
   // test pushToDataLayer is called
   test("pushToDataLayer is called", () => {
-    // Create the main content div
-    const mainContent = document.createElement("div");
-    mainContent.id = "main-content";
-
-    // Create the anchor element
-    const href = document.createElement("A");
-    href.textContent = "Change";
-    href.setAttribute("href", "http://localhost?edit=true");
-
-    // Create the form element
-    const form = document.createElement("form");
-    form.appendChild(href);
-    mainContent.appendChild(form);
-
-    // Append the main content div to the document body
-    document.body.appendChild(mainContent);
-
+    document.body.innerHTML = `
+  <main id="main-content">
+    <form>
+      <a id="change_link" href="http://localhost?edit=true">Change</a>
+    </form>
+  </main>
+`;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
     // Add a click event listener to the anchor element
     href.addEventListener("click", (event) => {
       newInstance.trackFormChange(event);
@@ -100,83 +91,71 @@ describe("FormChangeTracker", () => {
 
   // test trackFormChange accept Change Link
   test("trackFormChange should return true if a Change link", () => {
-    const href = document.createElement("A");
-    href.textContent = "Change organisation type";
-
-    document.body.appendChild(href);
+    document.body.innerHTML = `<a id="change_link" href="http://localhost?edit=true">Change</a>`;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
     href.dispatchEvent(action);
     href.addEventListener("click", (event) => {
       expect(newInstance.trackFormChange(event)).toBe(true);
     });
-    document.body.removeChild(href);
   });
 
   // test trackFormChange does not accept Lang Toggle Link
   test("trackFormChange should return false if it is a Lang Toggle link", () => {
-    const href = document.createElement("A");
-    href.textContent = "Change organisation type";
-    href.setAttribute("hreflang", "en");
-
-    document.body.appendChild(href);
+    document.body.innerHTML = `<a id="change_link" href="http://localhost?edit=true hreflang="en">Change</a>`;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
     href.dispatchEvent(action);
     href.addEventListener("click", (event) => {
       expect(newInstance.trackFormChange(event)).toBe(false);
     });
-    document.body.removeChild(href);
   });
 
-  test;
   test("should return 'undefined' if parent element does not exist", () => {
-    const element = document.createElement("div");
-    expect(newInstance.getSection(element)).toBe("undefined");
+    document.body.innerHTML = `<a id="change_link" href="http://localhost?edit=true">Change</a>`;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(newInstance.getSection(href)).toBe("undefined");
   });
 
   test("should return text content of sibling with class 'govuk-summary-list__key'", () => {
-    const parentElement = document.createElement("div");
-    const siblingElement = document.createElement("div");
-    siblingElement.classList.add("govuk-summary-list__key");
-    siblingElement.textContent = "Expected Section";
-
-    const href = document.createElement("a");
-    parentElement.appendChild(href);
-
-    document.body.appendChild(siblingElement); // Sibling is added to the document body before the parent
-    document.body.appendChild(parentElement); // Parent is added to the document body
-
+    document.body.innerHTML = `
+    <div class="govuk-summary-list__key">Expected Section</div>
+    <div>
+      <a id="change_link">Change</a>
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
     expect(newInstance.getSection(href)).toBe("Expected Section");
   });
 
   test("should check and return text content of parent element if no matching sibling found", () => {
-    const parentElement = document.createElement("div");
-    parentElement.textContent = "Parent Content";
-
-    const element = document.createElement("div");
-    parentElement.appendChild(element);
-
-    expect(newInstance.getSection(element)).toBe("Parent Content");
+    document.body.innerHTML = `  
+    <div>
+    Postcode
+      <a id="change_link">Change</a> 
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(newInstance.getSection(href)).toBe("Postcode");
   });
 
   test("should return 'undefined' if no matching sibling found and parent has no text content", () => {
-    const parentElement = document.createElement("div");
+    document.body.innerHTML = `
+      <div>
+        <a id="change_link">Change</a>
+      </div>
+    `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
 
-    const element = document.createElement("div");
-    parentElement.appendChild(element);
-
-    expect(newInstance.getSection(element)).toBe("undefined");
+    expect(newInstance.getSection(href)).toBe("undefined");
   });
 
-  test("should return 'undefined' if sibling element is not a sibling of the provided element", () => {
-    const parentElement = document.createElement("div");
-    const siblingElement = document.createElement("div");
-    siblingElement.classList.add("govuk-summary-list__key");
-    siblingElement.textContent = "Expected Section";
-
-    // Add sibling element outside the parent element
-    document.body.appendChild(siblingElement);
-
-    const element = document.createElement("div");
-    parentElement.appendChild(element);
-
-    expect(newInstance.getSection(element)).toBe("undefined");
+  test("should return 'undefined' if summary list key has no text content", () => {
+    document.body.innerHTML = `
+    <div class="govuk-summary-list__key"></div>
+    <div>
+      <a id="change_link">Change</a>
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(newInstance.getSection(href)).toBe("undefined");
   });
 });

--- a/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -8,6 +8,11 @@ export class FormChangeTracker extends FormTracker {
 
   constructor() {
     super();
+    this.initialiseEventListener();
+  }
+
+  initialiseEventListener() {
+    document.addEventListener("click", this.trackFormChange.bind(this), false);
   }
 
   /**
@@ -15,7 +20,7 @@ export class FormChangeTracker extends FormTracker {
    *
    * @return {boolean} Returns true if the form change tracking is successful, otherwise false.
    */
-  trackFormChange(): boolean {
+  trackFormChange(event: Event): boolean {
     if (!window.DI.analyticsGa4.cookie.consent) {
       return false;
     }
@@ -26,23 +31,33 @@ export class FormChangeTracker extends FormTracker {
       return false;
     }
 
-    const submitUrl = this.getSubmitUrl(form);
+    let element: HTMLLinkElement = event.target as HTMLLinkElement;
+
+    // Ensure element is an <a> tag with "Change" text content and is not a lang toggle link
+    if (
+      element.tagName !== "A" ||
+      !this.isChangeLink(element) ||
+      element.hasAttribute("hreflang")
+    ) {
+      return false;
+    }
+
     const formChangeTrackerEvent: FormEventInterface = {
       event: this.eventType,
       event_data: {
         event_name: this.eventName,
         type: "undefined",
-        url: validateParameter(submitUrl, 100),
+        url: validateParameter(element.href, 500),
         text: "change", //put static value. Waiting final documentation on form change tracker,
-        section: validateParameter(this.getFieldLabel(), 100),
+        section: validateParameter(this.getSection(element), 100),
         action: "change response",
         external: "false",
-        link_domain: this.getDomain(submitUrl),
-        "link_path_parts.1": this.getDomainPath(submitUrl, 0),
-        "link_path_parts.2": this.getDomainPath(submitUrl, 1),
-        "link_path_parts.3": this.getDomainPath(submitUrl, 2),
-        "link_path_parts.4": this.getDomainPath(submitUrl, 3),
-        "link_path_parts.5": this.getDomainPath(submitUrl, 4),
+        link_domain: this.getDomain(element.href),
+        "link_path_parts.1": this.getDomainPath(element.href, 0),
+        "link_path_parts.2": this.getDomainPath(element.href, 1),
+        "link_path_parts.3": this.getDomainPath(element.href, 2),
+        "link_path_parts.4": this.getDomainPath(element.href, 3),
+        "link_path_parts.5": this.getDomainPath(element.href, 4),
       },
     };
 
@@ -55,8 +70,24 @@ export class FormChangeTracker extends FormTracker {
     }
   }
 
-  getSubmitterText(): string {
-    const submitButton = document.querySelector("form > button");
-    return submitButton?.textContent?.trim() ?? "undefined";
+  getSection(element: HTMLElement): string {
+    const parentElement = element.parentElement;
+
+    // Ensure the parent element exists
+    if (!parentElement) {
+      return "undefined";
+    }
+
+    let siblingElement = parentElement?.previousElementSibling;
+    while (siblingElement) {
+      if (siblingElement.classList.contains("govuk-summary-list__key")) {
+        const sectionValue = siblingElement.textContent?.trim() || "undefined";
+        return sectionValue;
+      }
+      siblingElement = siblingElement.previousElementSibling;
+    }
+    // If no matching sibling is found, check the parent element
+    const parentTextContent = parentElement.textContent?.trim() || "undefined";
+    return parentTextContent;
   }
 }

--- a/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -78,16 +78,22 @@ export class FormChangeTracker extends FormTracker {
       return "undefined";
     }
 
-    let siblingElement = parentElement?.previousElementSibling;
-    while (siblingElement) {
-      if (siblingElement.classList.contains("govuk-summary-list__key")) {
-        const sectionValue = siblingElement.textContent?.trim() || "undefined";
+    let parentSiblingElement = parentElement?.previousElementSibling;
+    while (parentSiblingElement) {
+      if (parentSiblingElement.classList.contains("govuk-summary-list__key")) {
+        const sectionValue =
+          parentSiblingElement.textContent?.trim() || "undefined";
         return sectionValue;
       }
-      siblingElement = siblingElement.previousElementSibling;
+      parentSiblingElement = parentSiblingElement.previousElementSibling;
     }
     // If no matching sibling is found, check the parent element
-    const parentTextContent = parentElement.textContent?.trim() || "undefined";
-    return parentTextContent;
+    let parentTextContent = "";
+    for (let node of parentElement.childNodes) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        parentTextContent += node.textContent?.trim() || "";
+      }
+    }
+    return parentTextContent || "undefined";
   }
 }

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -95,6 +95,18 @@ describe("navigationTracker", () => {
     href.dispatchEvent(action);
   });
 
+  //test trackNavigation doesn't accept change links
+  test("trackNavigation should return false if it is a change link", () => {
+    document.body.innerHTML = "<div></div>";
+    const href = document.createElement("A");
+    href.innerHTML = "Change answer";
+    href.setAttribute("href", "http://localhost?edit=true");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+
   //test pushToDataLayer is called
   test("pushToDataLayer is called", () => {
     const href = document.createElement("A");

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -83,6 +83,11 @@ export class NavigationTracker extends BaseTracker {
       element.href = "undefined";
     }
 
+    // Ignore change links
+    if (this.isChangeLink(element)) {
+      return false;
+    }
+
     const navigationTrackerEvent: NavigationEventInterface = {
       event: this.eventName,
       event_data: {

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -4,7 +4,6 @@ import {
   PageViewParametersInterface,
   PageViewEventInterface,
 } from "./pageViewTracker.interface";
-import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
 import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
@@ -147,18 +146,6 @@ describe("Cookie Management", () => {
     };
     instance.trackOnPageLoad(parameters);
     expect(instance.trackOnPageLoad).toReturnWith(false);
-  });
-});
-
-describe("Form Change Tracker Trigger", () => {
-  const spy = jest.spyOn(FormChangeTracker.prototype, "trackFormChange");
-
-  test("FormChange tracker is not triggered", () => {
-    const instance = new PageViewTracker();
-    const formChangeTracker = new FormChangeTracker();
-
-    instance.trackOnPageLoad(parameters);
-    expect(formChangeTracker.trackFormChange).not.toHaveBeenCalled();
   });
 });
 

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -4,7 +4,6 @@ import {
   PageViewEventInterface,
 } from "./pageViewTracker.interface";
 import { validateParameter } from "../../utils/validateParameter";
-import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
 import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
 
 export class PageViewTracker extends BaseTracker {
@@ -61,12 +60,6 @@ export class PageViewTracker extends BaseTracker {
         relying_party: this.getRelyingParty(),
       },
     };
-
-    //trigger form change tracking
-    if (document.location.href.includes("edit=true")) {
-      const formChangeTracker = new FormChangeTracker();
-      formChangeTracker.trackFormChange();
-    }
 
     try {
       this.pushToDataLayer(pageViewTrackerEvent);


### PR DESCRIPTION
### Description

The data team requested that the **formChangeTracker** be triggered when a user clicks on a link, rather than on the page where the user changes the details. Additionally, the **navigationTracker** was incorrectly firing when the user clicks on a change link. This PR addresses both issues.

##What was done

Remove old trigger from pageViewTracker which triggered formChangeTracker when there was edit=true in url.

Updated the FormChange Tracker to:

1.  Initialise EventListener: Added an EventListener to formChangeTracker which detect user clicks on "Change" links, triggering the tracker.
2. Create **isChangeLink** Function: Introduced the isChangeLink function to the baseTracker to be utilised by both the **formChangeTracker** and **navigationTracker**. This function examines the query parameters of a link to check for edit=true. The formChangeTracker uses this to identify and track "Change" links, while the navigationTracker uses it to exclude these links from tracking.
3.  Create **getSection** Function: Developed the getSection function for the formChangeTracker to obtain the section value. This function looks for a sibling element with the class `govuk-summary-list__key` next to the link's parent to extract the section value or checks the parent element's text content. It also invokes the **validateParameter** function to ensure the removal of any Personally Identifiable Information (PII).

Deleted getSubmitterText function and tests from formChangeTracker as no longer required.

##Added Unit Tests:

1. trackNavigation: Ensure it does not accept "Change" links.
4. trackFormChange: Verify it only accepts "Change" links.
5. pushToDataLayer: Confirm that if it is a "Change" link, pushToDataLayer is called.
6. isChangeLink: Verify that it returns true for "Change" links and false otherwise.
7. getSection Function: Test that it retrieves the section value from the summary list key element or parent content. If the section value is empty, it should return undefined.



### Tickets

[DAC-3613](https://govukverify.atlassian.net/browse/DAC-3613)

### Steps to Reproduce

1. Pull down this branch.
2. Run `npm run build`.
3. Copy the contents of dist/lib/analytics.js.
4. Paste the copied contents into the dist/public/javascripts/analytics.js file of the repo you want to test in.
7. Start the app as normal. 

##Repos with Change links

[ipv-cri-address-front](https://github.com/govuk-one-login/ipv-cri-address-front)
[ipv-cri-f2f-front](https://github.com/govuk-one-login/ipv-cri-f2f-front)

### Co-Authored By

### Checklist

[ ] - Are the commit messages for this PR in line with the GDS way?
[ ] - Have the changes in this PR been tested locally (if required)
[ ] - Have additional tests been added where required?
[ ] - Does the feature pass accessibility checks? (UI Components only)

### Additional Information

Tested in ipv-cri-address-front and ipv-cri-f2f-front repos.

<img width="1512" alt="Screenshot 2024-07-03 at 15 53 49" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/16faa633-a7f8-4a56-b01c-7da1676cab63">

<img width="1512" alt="Screenshot 2024-07-03 at 15 53 35" src="https://github.com/govuk-one-login/di-fec-ga4/assets/148252375/1361a3da-e36f-4e47-aee6-f72cf1225ebb">

<img width="765" alt="Screenshot 2024-07-12 at 17 44 34" src="https://github.com/user-attachments/assets/22e92e94-d9da-4ca2-9ce1-09559202d7b5">



[DAC-3613]: https://govukverify.atlassian.net/browse/DAC-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ