### PR TITLE
DFC-319 - Add persisting taxonomy values to GA4 package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "husky": "^4.3.8",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-localstorage-mock": "^2.4.26",
         "prettier": "^3.0.3",
         "terser-webpack-plugin": "^5.3.10",
         "ts-jest": "^29.1.1",
@@ -7185,6 +7186,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "husky": "^4.3.8",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-localstorage-mock": "^2.4.26",
     "prettier": "^3.0.3",
     "terser-webpack-plugin": "^5.3.10",
     "ts-jest": "^29.1.1",

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import "jest-localstorage-mock";
 import { PageViewTracker } from "./pageViewTracker";
 import {
   PageViewParametersInterface,
@@ -232,5 +233,21 @@ describe("Form Error Tracker Trigger", () => {
 
     instance.trackOnPageLoad(parameters);
     expect(formErrorTracker.trackFormError).not.toHaveBeenCalled();
+  });
+});
+
+describe("Persisting taxonomy level 2 values", () => {
+  const instance = new PageViewTracker();
+  test("Taxonomy level 2 is saved to localStorage", () => {
+    instance.trackOnPageLoad(parameters);
+    expect(localStorage.getItem("taxonomyLevel2")).toBe("taxo2");
+  });
+
+  test("Taxonomy level 2 is not saved to localStorage if value === 'persisted from previous page'", () => {
+    parameters.taxonomy_level2 = "persisted from previous page";
+    instance.trackOnPageLoad(parameters);
+    expect(localStorage.getItem("taxonomyLevel2")).not.toBe(
+      "persisted from previous page",
+    );
   });
 });

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -51,6 +51,15 @@ export class PageViewTracker extends BaseTracker {
       return false;
     }
 
+    // check for persisted taxonomies
+    let taxonomyLevel2: string = parameters.taxonomy_level2;
+    if (taxonomyLevel2 === "persisted from previous page") {
+      taxonomyLevel2 = localStorage.getItem("taxonomyLevel2")!;
+    } else {
+      // if taxonomy is not "persisted from...", then store this into localStorage
+      localStorage.setItem("taxonomyLevel2", taxonomyLevel2);
+    }
+
     const pageViewTrackerEvent: PageViewEventInterface = {
       event: this.eventName,
       page_view: {
@@ -62,7 +71,7 @@ export class PageViewTracker extends BaseTracker {
         status_code: validateParameter(parameters.statusCode.toString(), 3),
         title: validateParameter(parameters.englishPageTitle, 300),
         taxonomy_level1: validateParameter(parameters.taxonomy_level1, 100),
-        taxonomy_level2: validateParameter(parameters.taxonomy_level2, 100),
+        taxonomy_level2: validateParameter(taxonomyLevel2, 100),
         content_id: validateParameter(parameters.content_id, 100),
         logged_in_status: this.getLoggedInStatus(parameters.logged_in_status),
         dynamic: parameters.dynamic.toString(),


### PR DESCRIPTION
### Description
Adds the ability to persist taxonomy level 2 values dynamically between pages. This is functionality which will only be used in Auth, but adding the functionality to the GA4 package was a cleaner and simpler solution than directly adding this to the auth frontend

### Tickets
[DFC-319](https://govukverify.atlassian.net/browse/DFC-319)

### Steps to Reproduce
- Install package into a target repository
- Modify one of the page view trackers to change the taxonomy level 2 value to `persisted from previous page`
- Test the UI, the string from step 2 should be replaced with the previous pages taxonomy level 2 value in the DLP

### Checklist

[x] - Are the commit messages for this PR in line with the GDS way?
[x] - Have the changes in this PR been tested locally (if required)
[x] - Have additional tests been added where required?

[DFC-319]: https://govukverify.atlassian.net/browse/DFC-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ