### PR TITLE
[DFC-629] - Rename feature flags to positive

### DIFF
--- a/PACKAGE-README.md
+++ b/PACKAGE-README.md
@@ -95,8 +95,8 @@ The package is owned by the DI Frontend Capability team, part of the development
    window.DI.appInit can take another parameter: an object of settings. That can be used if you want to disable some options. This is the property of this settings object:
 
    - isDataSensitive (boolean): specify if form response tracker can be collect form inputs for tracking purposes (default set to true, this will redact PII)
-   - disableGa4Tracking (boolean): disable GA4 trackers
-   - disableUaTracking (boolean): disable Universal Analytics tracker
+   - enableGa4Tracking (boolean): enable/disable GA4 trackers
+   - enableUaTracking (boolean): enable/disable Universal Analytics tracker
    - cookieDomain (string): specify the domain the analytics consent cookie should be raised against (default is "account.gov.uk")
 
 Example of call:
@@ -109,8 +109,8 @@ window.DI.appInit(
   },
   {
     isDataSensitive: false,
-    disableGa4Tracking: true,
-    disableUaTracking: true,
+    enableGa4Tracking: true,
+    enableUaTracking: true,
     cookieDomain: "{{ cookieDomain }}",
   },
 );

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -46,5 +46,5 @@ The `analytics.js` file has to be included in the base nunjucks template (e.g: `
 which makes available all the javascript functions described above on the global window object in the browser.
 
 We then call our `appInit` (`src/index.ts`) function (which is now accessible on the global window
-object) in the same base nunjucks template which initialises analytics and the cookie banner. We pass the `containerId`s and `disableGa4Tracking` as parameters, `disableGa4Tracking`, `disableUaTracking` and `domain` as options;
+object) in the same base nunjucks template which initialises analytics and the cookie banner. We pass the `containerId`s and `enableGa4Tracking` as parameters, `enableGa4Tracking`, `enableUaTracking` and `domain` as options;
 these values can be injected by your `setLocal` middleware functions which grabs these values from the current environment.

--- a/src/analytics/core/core.interface.ts
+++ b/src/analytics/core/core.interface.ts
@@ -4,9 +4,9 @@ export interface AppConfigInterface {
 }
 
 export interface OptionsInterface {
-  enableGa4Tracking?: boolean;
+  enableGa4Tracking: boolean;
+  cookieDomain: string;
   enableUaTracking?: boolean;
-  cookieDomain?: string;
   isDataSensitive?: boolean;
   enableFormChangeTracking: boolean;
   enableFormErrorTracking: boolean;
@@ -15,3 +15,4 @@ export interface OptionsInterface {
   enablePageViewTracking: boolean;
   enableSelectContentTracking: boolean;
 }
+``;

--- a/src/analytics/core/core.interface.ts
+++ b/src/analytics/core/core.interface.ts
@@ -4,15 +4,14 @@ export interface AppConfigInterface {
 }
 
 export interface OptionsInterface {
-  enableGa4Tracking: boolean;
-  cookieDomain: string;
+  enableGa4Tracking?: boolean;
+  cookieDomain?: string;
   enableUaTracking?: boolean;
   isDataSensitive?: boolean;
-  enableFormChangeTracking: boolean;
-  enableFormErrorTracking: boolean;
-  enableFormResponseTracking: boolean;
-  enableNavigationTracking: boolean;
-  enablePageViewTracking: boolean;
-  enableSelectContentTracking: boolean;
+  enableFormChangeTracking?: boolean;
+  enableFormErrorTracking?: boolean;
+  enableFormResponseTracking?: boolean;
+  enableNavigationTracking?: boolean;
+  enablePageViewTracking?: boolean;
+  enableSelectContentTracking?: boolean;
 }
-``;

--- a/src/analytics/core/core.interface.ts
+++ b/src/analytics/core/core.interface.ts
@@ -4,8 +4,8 @@ export interface AppConfigInterface {
 }
 
 export interface OptionsInterface {
-  disableGa4Tracking?: boolean;
-  disableUaTracking?: boolean;
+  enableGa4Tracking?: boolean;
+  enableUaTracking?: boolean;
   cookieDomain?: string;
   isDataSensitive?: boolean;
   enableFormChangeTracking: boolean;

--- a/src/analytics/core/core.test.ts
+++ b/src/analytics/core/core.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "@jest/globals";
 import { Analytics } from "./core";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
-import { OptionsInterface } from "../core/core.interface";
+import { OptionsInterface } from "./core.interface";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("should initialize the ga4 class", () => {
   const options: OptionsInterface = {
-    disableGa4Tracking: false,
-    disableUaTracking: false,
+    enableGa4Tracking: true,
+    enableUaTracking: false,
     cookieDomain: "localhost",
     enableFormChangeTracking: true,
     enableFormErrorTracking: true,
@@ -42,20 +42,16 @@ describe("should initialize the ga4 class", () => {
   });
 
   test("tag manager script not added to document", () => {
+    options.enableGa4Tracking = false;
     document.body = document.createElement("body");
-    const newInstance = new Analytics(gtmId, {
-      ...options,
-      disableGa4Tracking: true,
-    });
+    const newInstance = new Analytics(gtmId, options);
     expect(document.getElementsByTagName("script").length).toEqual(0);
   });
 
   test("GA4 trackers not initialized", () => {
+    options.enableGa4Tracking = false;
     document.body = document.createElement("body");
-    const newInstance = new Analytics(gtmId, {
-      ...options,
-      disableGa4Tracking: true,
-    });
+    const newInstance = new Analytics(gtmId, options);
     expect(newInstance.navigationTracker).toEqual(undefined);
     expect(newInstance.formResponseTracker).toEqual(undefined);
   });

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -35,7 +35,7 @@ export class Analytics {
     this.enableFormChangeTracking = Boolean(options.enableFormChangeTracking);
 
     this.pageViewTracker = new PageViewTracker({
-      disableGa4Tracking: options.disableGa4Tracking,
+      enableGa4Tracking: options.enableGa4Tracking,
       enableFormChangeTracking: options.enableFormChangeTracking,
       enableFormErrorTracking: options.enableFormErrorTracking,
       enableFormResponseTracking: options.enableFormResponseTracking,
@@ -44,7 +44,7 @@ export class Analytics {
       enableSelectContentTracking: options.enableSelectContentTracking,
     });
 
-    if (!options.disableGa4Tracking) {
+    if (options.enableGa4Tracking) {
       this.pageViewTracker.pushToDataLayer({
         "gtm.allowlist": ["google"],
         "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -36,12 +36,14 @@ export class Analytics {
 
     this.pageViewTracker = new PageViewTracker({
       enableGa4Tracking: options.enableGa4Tracking,
+      enableUaTracking: options.enableUaTracking,
       enableFormChangeTracking: options.enableFormChangeTracking,
       enableFormErrorTracking: options.enableFormErrorTracking,
       enableFormResponseTracking: options.enableFormResponseTracking,
       enableNavigationTracking: options.enableNavigationTracking,
       enablePageViewTracking: options.enablePageViewTracking,
       enableSelectContentTracking: options.enableSelectContentTracking,
+      cookieDomain: options.cookieDomain,
     });
 
     if (options.enableGa4Tracking) {

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -198,7 +198,6 @@ describe("Form Change Tracker Trigger", () => {
       ...options,
       enableGa4Tracking: false,
     });
-    // const formChangeTracker = new FormChangeTracker();
 
     instance.trackOnPageLoad(getParameters());
     expect(spy).not.toHaveBeenCalled();
@@ -218,13 +217,10 @@ describe("Form Error Tracker Trigger", () => {
   });
 
   const spy = jest.spyOn(FormErrorTracker.prototype, "trackFormError");
-  // const instance = new PageViewTracker(options);
-  // const formErrorTracker = new FormErrorTracker();
   window.DI.analyticsGa4.cookie.consent = true;
   window.DI.analyticsGa4.cookie.hasCookie = true;
 
   test("trackOnPageLoad should called form error function and return false if form error message exists", () => {
-    // const spy2 = jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
     document.body.innerHTML =
       '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
     instance.trackOnPageLoad(getParameters());
@@ -259,12 +255,7 @@ describe("Form Error Tracker Trigger", () => {
   test("FormError tracker is deactivated", () => {
     document.body.innerHTML =
       '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
-
-    const instance = new PageViewTracker({
-      ...options,
-      enableFormErrorTracking: false,
-    });
-
+    instance.enableFormErrorTracking = false;
     instance.trackOnPageLoad(getParameters());
     expect(formErrorTracker.trackFormError).not.toHaveBeenCalled();
   });

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import "jest-localstorage-mock";
-import { PageViewTracker } from "./pageViewTracker";
+
 import {
   PageViewParametersInterface,
   PageViewEventInterface,
 } from "./pageViewTracker.interface";
+import { PageViewTracker } from "./pageViewTracker";
+import { OptionsInterface } from "../core/core.interface";
 import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
 import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
-import { OptionsInterface } from "../core/core.interface";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
@@ -25,8 +26,8 @@ const getParameters = (
 });
 
 const options: OptionsInterface = {
-  enableGa4Tracking: false,
-  enableUaTracking: false,
+  enableGa4Tracking: true,
+  enableUaTracking: true,
   cookieDomain: "localhost",
   enableFormChangeTracking: true,
   enableFormErrorTracking: true,
@@ -37,127 +38,128 @@ const options: OptionsInterface = {
 };
 
 describe("pageViewTracker", () => {
-  const newInstance = new PageViewTracker(options);
-  const spy = jest.spyOn(PageViewTracker.prototype, "pushToDataLayer");
-  test("pageView is deactivated", () => {
-    const instance = new PageViewTracker({
-      ...options,
-      enablePageViewTracking: false,
-    });
-    instance.trackOnPageLoad(getParameters());
-    expect(instance.trackOnPageLoad).toReturnWith(false);
+  const instance = new PageViewTracker({
+    ...options,
+    enablePageViewTracking: true,
   });
+  const spy = jest.spyOn(PageViewTracker.prototype, "pushToDataLayer");
 
   test("pushToDataLayer is called", () => {
-    newInstance.trackOnPageLoad(getParameters());
-    expect(newInstance.pushToDataLayer).toBeCalled();
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.pushToDataLayer).toBeCalled();
   });
 
   test("pushToDataLayer is called with the good data", () => {
     const parameters = getParameters();
     const dataLayerEvent: PageViewEventInterface = {
-      event: newInstance.eventName,
+      event: instance.eventName,
       page_view: {
-        language: newInstance.getLanguage(),
-        location: newInstance.getLocation(),
-        organisations: newInstance.organisations,
+        language: instance.getLanguage(),
+        location: instance.getLocation(),
+        organisations: instance.organisations,
         primary_publishing_organisation:
-          newInstance.primary_publishing_organisation,
-        referrer: newInstance.getReferrer(),
+          instance.primary_publishing_organisation,
+        referrer: instance.getReferrer(),
         status_code: parameters.statusCode.toString(),
         title: parameters.englishPageTitle,
         taxonomy_level1: parameters.taxonomy_level1,
         taxonomy_level2: parameters.taxonomy_level2,
         content_id: parameters.content_id,
-        logged_in_status: newInstance.getLoggedInStatus(
+        logged_in_status: instance.getLoggedInStatus(
           parameters.logged_in_status,
         ),
         dynamic: parameters.dynamic.toString(),
-        first_published_at: newInstance.getFirstPublishedAt(),
-        updated_at: newInstance.getUpdatedAt(),
-        relying_party: newInstance.getRelyingParty(),
+        first_published_at: instance.getFirstPublishedAt(),
+        updated_at: instance.getUpdatedAt(),
+        relying_party: instance.getRelyingParty(),
       },
     };
-    newInstance.trackOnPageLoad(getParameters());
-    expect(newInstance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
   });
 
-test("pushToDataLayer is called with the good data", () => {
-  const parameters = getParameters();
-  const dataLayerEvent: PageViewEventInterface = {
-    event: newInstance.eventName,
-    page_view: {
-      language: newInstance.getLanguage(),
-      location: newInstance.getLocation(),
-      organisations: newInstance.organisations,
-      primary_publishing_organisation:
-        newInstance.primary_publishing_organisation,
-      referrer: newInstance.getReferrer(),
-      status_code: parameters.statusCode.toString(),
-      title: parameters.englishPageTitle,
-      taxonomy_level1: parameters.taxonomy_level1,
-      taxonomy_level2: parameters.taxonomy_level2,
-      content_id: parameters.content_id,
-      logged_in_status: newInstance.getLoggedInStatus(
-        parameters.logged_in_status,
-      ),
-      dynamic: parameters.dynamic.toString(),
-      first_published_at: newInstance.getFirstPublishedAt(),
-      updated_at: newInstance.getUpdatedAt(),
-      relying_party: newInstance.getRelyingParty(),
-    },
-  };
-  newInstance.trackOnPageLoad(parameters);
-  expect(newInstance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
-});
+  test("pushToDataLayer is called with the good data", () => {
+    const parameters = getParameters();
+    const dataLayerEvent: PageViewEventInterface = {
+      event: instance.eventName,
+      page_view: {
+        language: instance.getLanguage(),
+        location: instance.getLocation(),
+        organisations: instance.organisations,
+        primary_publishing_organisation:
+          instance.primary_publishing_organisation,
+        referrer: instance.getReferrer(),
+        status_code: parameters.statusCode.toString(),
+        title: parameters.englishPageTitle,
+        taxonomy_level1: parameters.taxonomy_level1,
+        taxonomy_level2: parameters.taxonomy_level2,
+        content_id: parameters.content_id,
+        logged_in_status: instance.getLoggedInStatus(
+          parameters.logged_in_status,
+        ),
+        dynamic: parameters.dynamic.toString(),
+        first_published_at: instance.getFirstPublishedAt(),
+        updated_at: instance.getUpdatedAt(),
+        relying_party: instance.getRelyingParty(),
+      },
+    };
+    instance.trackOnPageLoad(parameters);
+    expect(instance.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
 
-test("getLoggedInStatus returns the good data if logged in", () => {
-  const status = newInstance.getLoggedInStatus(true);
-  expect(status).toBe("logged in");
-});
+  test("pageView is deactivated", () => {
+    instance.enablePageViewTracking = false;
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.trackOnPageLoad).toReturnWith(false);
+  });
 
-test("getLoggedInStatus returns the good data if logged out", () => {
-  const status = newInstance.getLoggedInStatus(false);
-  expect(status).toBe("logged out");
-});
+  test("getLoggedInStatus returns the good data if logged in", () => {
+    const status = instance.getLoggedInStatus(true);
+    expect(status).toBe("logged in");
+  });
 
-test("getLoggedInStatus returns the good data if loggedinstatus is undefined", () => {
-  const status = newInstance.getLoggedInStatus(undefined);
-  expect(status).toBe("undefined");
-});
+  test("getLoggedInStatus returns the good data if logged out", () => {
+    const status = instance.getLoggedInStatus(false);
+    expect(status).toBe("logged out");
+  });
 
-test("getRelyingParty returns the good data", () => {
-  const relyingParty = newInstance.getRelyingParty();
-  expect(relyingParty).toBe("localhost");
-});
+  test("getLoggedInStatus returns the good data if loggedinstatus is undefined", () => {
+    const status = instance.getLoggedInStatus(undefined);
+    expect(status).toBe("undefined");
+  });
 
-test("getFirstPublishedAt returns undefined if first published-at tag doesn't exists", () => {
-  const firstPublishedAt = newInstance.getFirstPublishedAt();
-  expect(firstPublishedAt).toBe("undefined");
-});
+  test("getRelyingParty returns the good data", () => {
+    const relyingParty = instance.getRelyingParty();
+    expect(relyingParty).toBe("localhost");
+  });
 
-test("getFirstPublishedAt returns the good data if first published-at tag exists", () => {
-  const newTag = document.createElement("meta");
-  newTag.setAttribute("name", "govuk:first-published-at");
-  newTag.setAttribute("content", "2022-09-01T00:00:00.000Z");
-  document.head.appendChild(newTag);
-  const firstPublishedAt = newInstance.getFirstPublishedAt();
-  expect(firstPublishedAt).toBe("2022-09-01T00:00:00.000Z");
-});
+  test("getFirstPublishedAt returns undefined if first published-at tag doesn't exists", () => {
+    const firstPublishedAt = instance.getFirstPublishedAt();
+    expect(firstPublishedAt).toBe("undefined");
+  });
 
-test("getUpdatedAt returns undefined if updated-at tag doesn't exists", () => {
-  const updatedAt = newInstance.getUpdatedAt();
-  expect(updatedAt).toBe("undefined");
-});
+  test("getFirstPublishedAt returns the good data if first published-at tag exists", () => {
+    const newTag = document.createElement("meta");
+    newTag.setAttribute("name", "govuk:first-published-at");
+    newTag.setAttribute("content", "2022-09-01T00:00:00.000Z");
+    document.head.appendChild(newTag);
+    const firstPublishedAt = instance.getFirstPublishedAt();
+    expect(firstPublishedAt).toBe("2022-09-01T00:00:00.000Z");
+  });
 
-test("getUpdatedAt returns the good data if updated-at tag exists", () => {
-  const newTag = document.createElement("meta");
-  newTag.setAttribute("name", "govuk:updated-at");
-  newTag.setAttribute("content", "2022-09-02T00:00:00.000Z");
-  document.head.appendChild(newTag);
-  const updatedAt = newInstance.getUpdatedAt();
-  expect(updatedAt).toBe("2022-09-02T00:00:00.000Z");
-});
+  test("getUpdatedAt returns undefined if updated-at tag doesn't exists", () => {
+    const updatedAt = instance.getUpdatedAt();
+    expect(updatedAt).toBe("undefined");
+  });
+
+  test("getUpdatedAt returns the good data if updated-at tag exists", () => {
+    const newTag = document.createElement("meta");
+    newTag.setAttribute("name", "govuk:updated-at");
+    newTag.setAttribute("content", "2022-09-02T00:00:00.000Z");
+    document.head.appendChild(newTag);
+    const updatedAt = instance.getUpdatedAt();
+    expect(updatedAt).toBe("2022-09-02T00:00:00.000Z");
+  });
 });
 
 describe("pageViewTracker test disable ga4 tracking option", () => {

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -16,8 +16,8 @@ export class PageViewTracker extends BaseTracker {
   constructor(options: OptionsInterface) {
     super();
     this.enableGa4Tracking = options.enableGa4Tracking || false;
-    this.enableFormErrorTracking = options.enableFormErrorTracking;
-    this.enablePageViewTracking = options.enablePageViewTracking;
+    this.enableFormErrorTracking = options.enableFormErrorTracking || true;
+    this.enablePageViewTracking = options.enablePageViewTracking || true;
   }
 
   /**

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -9,13 +9,13 @@ import { OptionsInterface } from "../core/core.interface";
 
 export class PageViewTracker extends BaseTracker {
   eventName: string = "page_view_ga4";
-  disableGa4Tracking: boolean = false;
+  enableGa4Tracking: boolean;
   enableFormErrorTracking: boolean;
   enablePageViewTracking: boolean;
 
   constructor(options: OptionsInterface) {
     super();
-    this.disableGa4Tracking = options.disableGa4Tracking || false;
+    this.enableGa4Tracking = options.enableGa4Tracking || false;
     this.enableFormErrorTracking = options.enableFormErrorTracking;
     this.enablePageViewTracking = options.enablePageViewTracking;
   }
@@ -26,7 +26,6 @@ export class PageViewTracker extends BaseTracker {
    * @param {PageViewParametersInterface} parameters - The parameters for the page view event.
    * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
    */
-
   trackOnPageLoad(parameters: PageViewParametersInterface): boolean {
     if (
       window.DI.analyticsGa4.cookie.hasCookie &&
@@ -34,7 +33,7 @@ export class PageViewTracker extends BaseTracker {
     ) {
       return false;
     }
-    if (this.disableGa4Tracking) {
+    if (!this.enableGa4Tracking) {
       return false;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,19 @@ declare global {
 
 const appInit = function (
   settings: AppConfigInterface,
-  options: OptionsInterface,
+  options: OptionsInterface = {},
 ): boolean {
-  const defaultedOptions = applyDefaults(options, { isDataSensitive: true });
+  const defaultedOptions = applyDefaults(options, {
+    isDataSensitive: true,
+    enableGa4Tracking: false,
+    enableUaTracking: false,
+    enableFormChangeTracking: true,
+    enableFormErrorTracking: true,
+    enableFormResponseTracking: true,
+    enableNavigationTracking: true,
+    enablePageViewTracking: true,
+    enableSelectContentTracking: true,
+  });
 
   try {
     window.DI.analyticsGa4 = new Analytics(

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const appInit = function (
       defaultedOptions,
     );
 
-    if (!defaultedOptions.disableUaTracking) {
+    if (defaultedOptions.enableUaTracking) {
       window.DI.analyticsGa4.uaContainerId = settings.uaContainerId;
       window.DI.analyticsUa.init();
     }


### PR DESCRIPTION
### Description

The initial implementation of this package had the feature flag naming as `disabled` which has been a frequent piece of feedback from the pods and does not conform with the GDS way. This work renames those flags and mirrors the feature flag logic so that the pods can rename their environment variables to use `enabled` and avoid confusion

### Tickets

[DFC-629](https://govukverify.atlassian.net/browse/DFC-629)

### Steps to Reproduce

- Built the package
- Place the analytics.js file in the local instance of any repo
NOTE: If you use a CRI for this, remember the additional common-express steps
- Update the feature flag references in the consuming repo
- Test in the tag manager, expected behaviour is:

GA4 Flag set to `true`: GA4 is enabled
GA4 Flag set to `false`: GA4 is disabled
GA4 Flag not provided: GA4 is disabled

There should be no default value logic remaining within this repository as the middleware functions of the consuming repos currently require an environment variable to pass through to the package, so our default value logic was never reached.

### Co-Authored By

N/A

### Checklist

[x] - Are the commit messages for this PR in line with the GDS way?
[ ] - Have the changes in this PR been tested locally (if required)
[x] - Have additional tests been added where required?
[x] - Does the feature pass accessibility checks? (UI Components only)

### Additional Information


[DFC-629]: https://govukverify.atlassian.net/browse/DFC-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ