### PR TITLE
DFC-626 | FEC GA4 | Select Content | As a OL dev, I want to access a wrapper for each GA4 tracker, so that I can manage each variable individually without impacting the GA4 global flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm ci && npm run prettier && webpack --config webpack.config.js --mode production",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
-    "precommit": "npm run prettier && git add .",
+    "precommit": "npm run prettier",
     "pub": "cp PACKAGE-README.md dist/README.md && cp package.json dist && cd dist && npm publish --access public",
     "test": "jest",
     "test:coverage": "jest --coverage src"

--- a/src/analytics/core/core.interface.ts
+++ b/src/analytics/core/core.interface.ts
@@ -8,4 +8,10 @@ export interface OptionsInterface {
   disableUaTracking?: boolean;
   cookieDomain?: string;
   isDataSensitive?: boolean;
+  enableFormChangeTracking: boolean;
+  enableFormErrorTracking: boolean;
+  enableFormResponseTracking: boolean;
+  enableNavigationTracking: boolean;
+  enablePageViewTracking: boolean;
+  enableSelectContentTracking: boolean;
 }

--- a/src/analytics/core/core.test.ts
+++ b/src/analytics/core/core.test.ts
@@ -1,19 +1,31 @@
 import { describe, expect, test } from "@jest/globals";
 import { Analytics } from "./core";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
+import { OptionsInterface } from "../core/core.interface";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("should initialize the ga4 class", () => {
+  const options: OptionsInterface = {
+    disableGa4Tracking: false,
+    disableUaTracking: false,
+    cookieDomain: "localhost",
+    enableFormChangeTracking: true,
+    enableFormErrorTracking: true,
+    enableFormResponseTracking: true,
+    enableNavigationTracking: true,
+    enablePageViewTracking: true,
+    enableSelectContentTracking: true,
+  };
   const gtmId = "GTM-XXXX";
 
   test("gtmId property", () => {
-    const newInstance = new Analytics(gtmId, {});
+    const newInstance = new Analytics(gtmId, options);
     expect(newInstance.gtmId).toEqual(gtmId);
   });
 
   test("pageViewTracker property", () => {
-    const newInstance = new Analytics(gtmId, {});
+    const newInstance = new Analytics(gtmId, options);
     expect(newInstance.pageViewTracker).toBeInstanceOf(PageViewTracker);
   });
 
@@ -22,7 +34,7 @@ describe("should initialize the ga4 class", () => {
   });
 
   test("tag manager script added to document", () => {
-    const newInstance = new Analytics(gtmId, {});
+    const newInstance = new Analytics(gtmId, options);
     newInstance.loadGtmScript(newInstance.gtmId);
     expect(document.getElementsByTagName("script")[0].src).toEqual(
       "https://www.googletagmanager.com/gtm.js?id=GTM-XXXX",
@@ -31,13 +43,19 @@ describe("should initialize the ga4 class", () => {
 
   test("tag manager script not added to document", () => {
     document.body = document.createElement("body");
-    const newInstance = new Analytics(gtmId, { disableGa4Tracking: true });
+    const newInstance = new Analytics(gtmId, {
+      ...options,
+      disableGa4Tracking: true,
+    });
     expect(document.getElementsByTagName("script").length).toEqual(0);
   });
 
   test("GA4 trackers not initialized", () => {
     document.body = document.createElement("body");
-    const newInstance = new Analytics(gtmId, { disableGa4Tracking: true });
+    const newInstance = new Analytics(gtmId, {
+      ...options,
+      disableGa4Tracking: true,
+    });
     expect(newInstance.navigationTracker).toEqual(undefined);
     expect(newInstance.formResponseTracker).toEqual(undefined);
   });

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -29,7 +29,7 @@ export class Analytics {
     this.cookie = new Cookie(options.cookieDomain);
     this.isDataSensitive = Boolean(options.isDataSensitive);
     this.enableFormResponseTracking = Boolean(
-      options.enableFormResponseTracking
+      options.enableFormResponseTracking,
     );
     this.enableNavigationTracking = Boolean(options.enableNavigationTracking);
     this.enableFormChangeTracking = Boolean(options.enableFormChangeTracking);
@@ -41,7 +41,7 @@ export class Analytics {
       enableFormResponseTracking: options.enableFormResponseTracking,
       enableNavigationTracking: options.enableNavigationTracking,
       enablePageViewTracking: options.enablePageViewTracking,
-      enableSelectContentTracking: options.enableSelectContentTracking
+      enableSelectContentTracking: options.enableSelectContentTracking,
     });
 
     if (!options.disableGa4Tracking) {
@@ -49,17 +49,17 @@ export class Analytics {
         "gtm.allowlist": ["google"],
         "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
         "gtm.start": new Date().getTime(),
-        event: "gtm.js"
+        event: "gtm.js",
       });
       this.formResponseTracker = new FormResponseTracker(
         this.isDataSensitive,
-        this.enableFormResponseTracking
+        this.enableFormResponseTracking,
       );
       this.navigationTracker = new NavigationTracker(
-        this.enableNavigationTracking
+        this.enableNavigationTracking,
       );
       this.formChangeTracker = new FormChangeTracker(
-        this.enableFormChangeTracking
+        this.enableFormChangeTracking,
       );
       if (this.cookie.consent) {
         this.loadGtmScript(this.gtmId);

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -7,6 +7,8 @@ import { OptionsInterface } from "./core.interface";
 export class Analytics {
   gtmId: string;
   isDataSensitive: boolean | undefined;
+  enableFormResponseTracking: boolean;
+  enableNavigationTracking: boolean;
   uaContainerId: string | undefined;
   pageViewTracker: PageViewTracker | undefined;
   navigationTracker: NavigationTracker | undefined;
@@ -23,9 +25,19 @@ export class Analytics {
 
     this.cookie = new Cookie(options.cookieDomain);
     this.isDataSensitive = Boolean(options.isDataSensitive);
+    this.enableFormResponseTracking = Boolean(
+      options.enableFormResponseTracking,
+    );
+    this.enableNavigationTracking = Boolean(options.enableNavigationTracking);
 
     this.pageViewTracker = new PageViewTracker({
       disableGa4Tracking: options.disableGa4Tracking,
+      enableFormChangeTracking: options.enableFormChangeTracking,
+      enableFormErrorTracking: options.enableFormErrorTracking,
+      enableFormResponseTracking: options.enableFormResponseTracking,
+      enableNavigationTracking: options.enableNavigationTracking,
+      enablePageViewTracking: options.enablePageViewTracking,
+      enableSelectContentTracking: options.enableSelectContentTracking,
     });
 
     if (!options.disableGa4Tracking) {
@@ -35,8 +47,13 @@ export class Analytics {
         "gtm.start": new Date().getTime(),
         event: "gtm.js",
       });
-      this.formResponseTracker = new FormResponseTracker(this.isDataSensitive);
-      this.navigationTracker = new NavigationTracker();
+      this.formResponseTracker = new FormResponseTracker(
+        this.isDataSensitive,
+        this.enableFormResponseTracking,
+      );
+      this.navigationTracker = new NavigationTracker(
+        this.enableNavigationTracking,
+      );
       if (this.cookie.consent) {
         this.loadGtmScript(this.gtmId);
       }

--- a/src/analytics/core/core.ts
+++ b/src/analytics/core/core.ts
@@ -10,6 +10,7 @@ export class Analytics {
   isDataSensitive: boolean | undefined;
   enableFormResponseTracking: boolean;
   enableNavigationTracking: boolean;
+  enableFormChangeTracking: boolean;
   uaContainerId: string | undefined;
   pageViewTracker: PageViewTracker | undefined;
   navigationTracker: NavigationTracker | undefined;
@@ -28,9 +29,10 @@ export class Analytics {
     this.cookie = new Cookie(options.cookieDomain);
     this.isDataSensitive = Boolean(options.isDataSensitive);
     this.enableFormResponseTracking = Boolean(
-      options.enableFormResponseTracking,
+      options.enableFormResponseTracking
     );
     this.enableNavigationTracking = Boolean(options.enableNavigationTracking);
+    this.enableFormChangeTracking = Boolean(options.enableFormChangeTracking);
 
     this.pageViewTracker = new PageViewTracker({
       disableGa4Tracking: options.disableGa4Tracking,
@@ -39,7 +41,7 @@ export class Analytics {
       enableFormResponseTracking: options.enableFormResponseTracking,
       enableNavigationTracking: options.enableNavigationTracking,
       enablePageViewTracking: options.enablePageViewTracking,
-      enableSelectContentTracking: options.enableSelectContentTracking,
+      enableSelectContentTracking: options.enableSelectContentTracking
     });
 
     if (!options.disableGa4Tracking) {
@@ -47,16 +49,18 @@ export class Analytics {
         "gtm.allowlist": ["google"],
         "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
         "gtm.start": new Date().getTime(),
-        event: "gtm.js",
+        event: "gtm.js"
       });
       this.formResponseTracker = new FormResponseTracker(
         this.isDataSensitive,
-        this.enableFormResponseTracking,
+        this.enableFormResponseTracking
       );
       this.navigationTracker = new NavigationTracker(
-        this.enableNavigationTracking,
+        this.enableNavigationTracking
       );
-      this.formChangeTracker = new FormChangeTracker();
+      this.formChangeTracker = new FormChangeTracker(
+        this.enableFormChangeTracking
+      );
       if (this.cookie.consent) {
         this.loadGtmScript(this.gtmId);
       }

--- a/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -36,7 +36,7 @@ describe("FormChangeTracker", () => {
     action = new MouseEvent("click", {
       view: window,
       bubbles: true,
-      cancelable: true
+      cancelable: true,
     });
   });
 

--- a/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -31,12 +31,18 @@ describe("FormChangeTracker", () => {
     jest.spyOn(FormChangeTracker.prototype, "getSection");
     jest.spyOn(FormChangeTracker.prototype, "initialiseEventListener");
 
-    newInstance = new FormChangeTracker();
+    const enableFormChangeTracking = true;
+    newInstance = new FormChangeTracker(enableFormChangeTracking);
     action = new MouseEvent("click", {
       view: window,
       bubbles: true,
-      cancelable: true,
+      cancelable: true
     });
+  });
+
+  test("form change should be deactivated, if flag is set to false", () => {
+    const instance = new FormChangeTracker(false);
+    expect(instance.trackFormChange).not.toBeCalled();
   });
 
   test("new instance should call initialiseEventListener", () => {

--- a/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -1,13 +1,16 @@
 import { validateParameter } from "../../utils/validateParameter";
 import { FormTracker } from "../formTracker/formTracker";
 import { FormEventInterface } from "../formTracker/formTracker.interface";
+import { OptionsInterface } from "../core/core.interface";
 
 export class FormChangeTracker extends FormTracker {
   eventName: string = "form_change_response";
   eventType: string = "event_data";
+  enableFormChangeTracking: boolean;
 
-  constructor() {
+  constructor(enableFormChangeTracking: boolean) {
     super();
+    this.enableFormChangeTracking = enableFormChangeTracking;
     this.initialiseEventListener();
   }
 
@@ -22,6 +25,10 @@ export class FormChangeTracker extends FormTracker {
    */
   trackFormChange(event: Event): boolean {
     if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+
+    if (!this.enableFormChangeTracking) {
       return false;
     }
 
@@ -57,8 +64,8 @@ export class FormChangeTracker extends FormTracker {
         "link_path_parts.2": this.getDomainPath(element.href, 1),
         "link_path_parts.3": this.getDomainPath(element.href, 2),
         "link_path_parts.4": this.getDomainPath(element.href, 3),
-        "link_path_parts.5": this.getDomainPath(element.href, 4),
-      },
+        "link_path_parts.5": this.getDomainPath(element.href, 4)
+      }
     };
 
     try {

--- a/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -64,8 +64,8 @@ export class FormChangeTracker extends FormTracker {
         "link_path_parts.2": this.getDomainPath(element.href, 1),
         "link_path_parts.3": this.getDomainPath(element.href, 2),
         "link_path_parts.4": this.getDomainPath(element.href, 3),
-        "link_path_parts.5": this.getDomainPath(element.href, 4)
-      }
+        "link_path_parts.5": this.getDomainPath(element.href, 4),
+      },
     };
 
     try {

--- a/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -16,9 +16,33 @@ describe("form with multiple fields", () => {
 
   const spy = jest.spyOn(FormResponseTracker.prototype, "pushToDataLayer");
 
+  test("trackFormResponse should return false if tracking is deactivated", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+    const isDataSensitive = false;
+    const enableFormResponseTracking = false;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    expect(instance.trackFormResponse).toReturnWith(false);
+  });
+
   test("event fired and data layer defined for each of the fields", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action= "/test-url" method= "post">' +
@@ -179,7 +203,7 @@ describe("FormResponseTracker", () => {
   );
 
   test("new instance should call initialiseEventListener", () => {
-    const instance = new FormResponseTracker(true);
+    const instance = new FormResponseTracker(true, true);
     expect(instance.initialiseEventListener).toBeCalled();
   });
 });
@@ -194,7 +218,11 @@ describe("form with radio buttons", () => {
 
   test("datalayer event should be defined as default", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -231,7 +259,11 @@ describe("form with radio buttons", () => {
 
   test("datalayer event should redact information if data is flagged as sensitive", () => {
     const isDataSensitive = true;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
 
     document.body.innerHTML =
       '<div id="main-content">' +
@@ -278,7 +310,11 @@ describe("form with input checkbox", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
 
     document.body.innerHTML =
       '<div id="main-content">' +
@@ -324,7 +360,11 @@ describe("form with input text", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -366,7 +406,11 @@ describe("form with input textarea", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -408,7 +452,11 @@ describe("form with dropdown", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
-    const instance = new FormResponseTracker(isDataSensitive);
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -446,7 +494,7 @@ describe("Cookie Management", () => {
     cancelable: true,
   });
   const spy = jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
-  const instance = new FormResponseTracker(true);
+  const instance = new FormResponseTracker(true, true);
 
   test("trackFormResponse should return false if not cookie consent", () => {
     window.DI.analyticsGa4.cookie.consent = false;
@@ -469,7 +517,7 @@ describe("cancel event if form is invalid", () => {
     cancelable: true,
   });
   const spy = jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
-  const instance = new FormResponseTracker(true);
+  const instance = new FormResponseTracker(true, true);
 
   test("trackFormResponse should return false if form is invalid", () => {
     window.DI.analyticsGa4.cookie.consent = true;

--- a/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -9,15 +9,17 @@ export class FormResponseTracker extends FormTracker {
   eventName: string = "form_response";
   eventType: string = "event_data";
   isDataSensitive: boolean;
+  enableFormResponseTracking: boolean;
 
   /**
    * Initializes a new instance of the FormResponseTracker class.
    *  * @param {boolean} isDataSensitive - Flag if data is sensitive
    *  * @return {void}
    */
-  constructor(isDataSensitive: boolean) {
+  constructor(isDataSensitive: boolean, enableFormResponseTracking: boolean) {
     super();
     this.isDataSensitive = isDataSensitive;
+    this.enableFormResponseTracking = enableFormResponseTracking;
     this.initialiseEventListener();
   }
 
@@ -41,6 +43,10 @@ export class FormResponseTracker extends FormTracker {
    */
   trackFormResponse(event: SubmitEvent): boolean {
     if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+
+    if (!this.enableFormResponseTracking) {
       return false;
     }
 

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -4,7 +4,8 @@ import { NavigationTracker } from "./navigationTracker";
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("navigationTracker", () => {
-  const newInstance = new NavigationTracker();
+  const enableNavigationTracking = true;
+  const newInstance = new NavigationTracker(enableNavigationTracking);
   const action = new MouseEvent("click", {
     view: window,
     bubbles: true,
@@ -21,7 +22,7 @@ describe("navigationTracker", () => {
   );
 
   test("new instance should call initialiseEventListener", () => {
-    const instance = new NavigationTracker();
+    const instance = new NavigationTracker(true);
     expect(newInstance.initialiseEventListener).toBeCalled();
   });
 
@@ -45,7 +46,19 @@ describe("navigationTracker", () => {
       expect(newInstance.pushToDataLayer).toBeCalled();
     });
   });
-
+  //test trackNavigation return false if tracker is deactivated
+  test("trackNavigation return false if tracker is deactivated", () => {
+    const instance = new NavigationTracker(false);
+    const href = document.createElement("BUTTON");
+    href.setAttribute("data-nav", "true");
+    href.setAttribute("data-link", "/next-url");
+    href.innerHTML = "Continue";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(instance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
   //test trackNavigation doesn't accept anything except button or link
   test("trackNavigation should return false if not a link or a button", () => {
     const href = document.createElement("div");
@@ -111,7 +124,7 @@ describe("Cookie Management", () => {
   test("trackNavigation should return false if not cookie consent", () => {
     const spy = jest.spyOn(NavigationTracker.prototype, "trackNavigation");
     window.DI.analyticsGa4.cookie.consent = false;
-    const instance = new NavigationTracker();
+    const instance = new NavigationTracker(true);
     const href = document.createElement("A");
     href.className = "govuk-footer__link";
     href.addEventListener("click", (event) => {
@@ -121,7 +134,7 @@ describe("Cookie Management", () => {
 });
 
 describe("getLinkType", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
   const action = new MouseEvent("click", {
     view: window,
     bubbles: true,
@@ -190,7 +203,7 @@ describe("getLinkType", () => {
 });
 
 describe("isExternalLink", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
 
   test("should return false for internal links", () => {
     const url = "http://localhost";
@@ -209,7 +222,7 @@ describe("isExternalLink", () => {
 });
 
 describe("isHeaderMenuBarLink", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
 
   test("should return true if link is inside the header tag", () => {
     document.body.innerHTML = `<header><a id="testLink">Link to GOV.UK</a></header>`;
@@ -231,7 +244,7 @@ describe("isHeaderMenuBarLink", () => {
 });
 
 describe("isFooterLink", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
 
   test("should return true if link is inside the footer tag", () => {
     document.body.innerHTML = `<footer><a id="testLink2">Link to GOV.UK</a></footer>`;
@@ -247,7 +260,7 @@ describe("isFooterLink", () => {
 });
 
 describe("isBackLink", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
 
   test("should return true if link is a back button", () => {
     document.body.innerHTML = `<a id="testLink3" href="/welcome" class="govuk-back-link">Back</a>`;
@@ -263,7 +276,7 @@ describe("isBackLink", () => {
 });
 
 describe("getSection", () => {
-  const newInstance = new NavigationTracker();
+  const newInstance = new NavigationTracker(true);
   const action = new MouseEvent("click", {
     view: window,
     bubbles: true,

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -4,9 +4,11 @@ import { validateParameter } from "../../utils/validateParameter";
 
 export class NavigationTracker extends BaseTracker {
   eventName: string = "event_data";
+  enableNavigationTracking: boolean;
 
-  constructor() {
+  constructor(enableNavigationTracking: boolean) {
     super();
+    this.enableNavigationTracking = enableNavigationTracking;
     this.initialiseEventListener();
   }
 
@@ -28,6 +30,9 @@ export class NavigationTracker extends BaseTracker {
    */
   trackNavigation(event: Event): boolean {
     if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+    if (!this.enableNavigationTracking) {
       return false;
     }
 

--- a/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -138,7 +138,10 @@ describe("pageViewTracker test disable ga4 tracking option", () => {
 });
 
 describe("Cookie Management", () => {
-  const spy = jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
+  jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
+  beforeEach(() => {
+    window.DI.analyticsGa4.cookie.consent = true;
+  });
 
   test("trackOnPageLoad should return false if visitor rejects cookie consent", () => {
     window.DI.analyticsGa4.cookie.consent = false;
@@ -172,21 +175,33 @@ describe("Cookie Management", () => {
   });
 });
 
-
-
-
 describe("Form Error Tracker Trigger", () => {
-  const spy = jest.spyOn(FormErrorTracker.prototype, "trackFormError");
-  const instance = new PageViewTracker(options);
-  const formErrorTracker = new FormErrorTracker();
+  let instance: PageViewTracker;
+  let formErrorTracker: FormErrorTracker;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.DI.analyticsGa4.cookie.consent = true;
+    jest.spyOn(FormErrorTracker.prototype, "trackFormError");
+    instance = new PageViewTracker(options);
+    formErrorTracker = new FormErrorTracker();
+  });
 
   test("trackOnPageLoad should called form error function and return false if form error message exists", () => {
-    const spy2 = jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
+    jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
 
     document.body.innerHTML =
       '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
     instance.trackOnPageLoad(parameters);
     expect(instance.trackOnPageLoad).toReturnWith(false);
+  });
+
+  test("FormError tracker is activated", () => {
+    document.body.innerHTML =
+      '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
+
+    instance.trackOnPageLoad(parameters);
+    expect(formErrorTracker.trackFormError).toHaveBeenCalled();
   });
 
   test("FormError tracker is not triggered", () => {
@@ -195,21 +210,7 @@ describe("Form Error Tracker Trigger", () => {
     expect(formErrorTracker.trackFormError).not.toBeCalled();
   });
 
-  // !!! FAILING TEST
-
-  // test("FormError tracker is activated", () => {
-  //   document.body.innerHTML =
-  //     '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
-
-  //   const instance = new PageViewTracker({
-  //     ...options,
-  //     enableFormErrorTracking: true
-  //   });
-  //   instance.trackOnPageLoad(parameters);
-  //   expect(formErrorTracker.trackFormError).toHaveBeenCalled();
-  // });
   test("FormError tracker is deactivated", () => {
-    // Setting up the DOM
     document.body.innerHTML =
       '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
 

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -6,13 +6,21 @@ import {
 import { validateParameter } from "../../utils/validateParameter";
 import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
 import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
+import { OptionsInterface } from "../core/core.interface";
 
 export class PageViewTracker extends BaseTracker {
   eventName: string = "page_view_ga4";
   disableGa4Tracking: boolean = false;
-  constructor(options: { disableGa4Tracking?: boolean } = {}) {
+  enableFormChangeTracking: boolean;
+  enableFormErrorTracking: boolean;
+  enablePageViewTracking: boolean;
+
+  constructor(options: OptionsInterface) {
     super();
     this.disableGa4Tracking = options.disableGa4Tracking || false;
+    this.enableFormChangeTracking = options.enableFormChangeTracking;
+    this.enableFormErrorTracking = options.enableFormErrorTracking;
+    this.enablePageViewTracking = options.enablePageViewTracking;
   }
 
   /**
@@ -21,8 +29,12 @@ export class PageViewTracker extends BaseTracker {
    * @param {PageViewParametersInterface} parameters - The parameters for the page view event.
    * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
    */
+
   trackOnPageLoad(parameters: PageViewParametersInterface): boolean {
     if (this.disableGa4Tracking) {
+      return false;
+    }
+    if (!this.enablePageViewTracking) {
       return false;
     }
 
@@ -35,7 +47,7 @@ export class PageViewTracker extends BaseTracker {
 
     //trigger form error tracking
     const errorTrigger = document.getElementsByClassName("govuk-error-message");
-    if (errorTrigger.length) {
+    if (errorTrigger.length && this.enableFormErrorTracking) {
       const formErrorTracker = new FormErrorTracker();
       formErrorTracker.trackFormError();
       return false;
@@ -62,8 +74,11 @@ export class PageViewTracker extends BaseTracker {
       },
     };
 
-    //trigger form change tracking
-    if (document.location.href.includes("edit=true")) {
+    // Trigger form change tracking if enabled and the URL contains "edit=true"
+    if (
+      window.location.href.includes("edit=true") &&
+      this.enableFormChangeTracking
+    ) {
       const formChangeTracker = new FormChangeTracker();
       formChangeTracker.trackFormChange();
     }

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -10,14 +10,12 @@ import { OptionsInterface } from "../core/core.interface";
 export class PageViewTracker extends BaseTracker {
   eventName: string = "page_view_ga4";
   disableGa4Tracking: boolean = false;
-  enableFormChangeTracking: boolean;
   enableFormErrorTracking: boolean;
   enablePageViewTracking: boolean;
 
   constructor(options: OptionsInterface) {
     super();
     this.disableGa4Tracking = options.disableGa4Tracking || false;
-    this.enableFormChangeTracking = options.enableFormChangeTracking;
     this.enableFormErrorTracking = options.enableFormErrorTracking;
     this.enablePageViewTracking = options.enablePageViewTracking;
   }
@@ -45,7 +43,9 @@ export class PageViewTracker extends BaseTracker {
     }
 
     //trigger form error tracking
+
     const errorTrigger = document.getElementsByClassName("govuk-error-message");
+
     if (errorTrigger.length && this.enableFormErrorTracking) {
       const formErrorTracker = new FormErrorTracker();
       formErrorTracker.trackFormError();
@@ -69,8 +69,8 @@ export class PageViewTracker extends BaseTracker {
         dynamic: parameters.dynamic.toString(),
         first_published_at: this.getFirstPublishedAt(),
         updated_at: this.getUpdatedAt(),
-        relying_party: this.getRelyingParty(),
-      },
+        relying_party: this.getRelyingParty()
+      }
     };
 
     try {

--- a/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -69,8 +69,8 @@ export class PageViewTracker extends BaseTracker {
         dynamic: parameters.dynamic.toString(),
         first_published_at: this.getFirstPublishedAt(),
         updated_at: this.getUpdatedAt(),
-        relying_party: this.getRelyingParty()
-      }
+        relying_party: this.getRelyingParty(),
+      },
     };
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ declare global {
 
 const appInit = function (
   settings: AppConfigInterface,
-  options: OptionsInterface = {},
+  options: OptionsInterface,
 ): boolean {
   const defaultedOptions = applyDefaults(options, { isDataSensitive: true });
 


### PR DESCRIPTION
### Description
Introduce wrappers for each variable, in each repo to ensure that they can be individually managed
### Tickets

[DFC-626](https://govukverify.atlassian.net/browse/DFC-626)

### Steps to Reproduce

1. **Build the Project:** Run `npm build` to generate the latest build artifacts.
2. **Copy the File:** Copy the `dist/lib/analytics.js` file from the build output.
3. **Replace the File:** In the repository where you want to test ( use demo app), replace the existing `analytics.js` file in the node modules with the one you copied.
4. **Update base.njk**: In the base.njk file, update the second object passed in the `appInit()` function to pass each of the flags. Toggle between different values to test their effect.
5. **Test:** Run the repository and connect with Tag Manager to verify that the flags are functioning correctly for each tracker.

### Co-Authored By

### Checklist

[ ] - Are the commit messages for this PR in line with the GDS way?
[ ] - Have the changes in this PR been tested locally (if required)
[ ] - Have additional tests been added where required?
[ ] - Does the feature pass accessibility checks? (UI Components only)

### Additional Information

I accidentally used DFC-240 instead of DFC-626 for some of the commit messages

### appInit Call found in base file 

<img width="528" alt="Screenshot 2024-07-26 at 12 22 15" src="https://github.com/user-attachments/assets/7ab4122a-6d8f-45f9-b67c-c5b555c91547">
