### PR TITLE
fix(DFC-642): remove buttons from the form elements list as they don'…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ window.DI.appInit(
 );
 ```
 
-> [!NOTE]
-> `window.DI.appInit` is a function loaded from `analytics.js`. That will create a new instance of our analytics library and store into window.DI.analyticsGa4
+> [!NOTE] > `window.DI.appInit` is a function loaded from `analytics.js`. That will create a new instance of our analytics library and store into window.DI.analyticsGa4
 
 # Analytics Cookie Consent
 
@@ -102,16 +101,17 @@ The Cookie class is responsible for managing cookies consent about analytics. It
 
 > [!TIP]
 > You can get analytics cookie consent status (true or false) by calling the function hasConsentForAnalytics:
->`window.DI.analyticsGa4.cookie.hasConsentForAnalytics();`
+> `window.DI.analyticsGa4.cookie.hasConsentForAnalytics();`
 
 > [!TIP]
 > You can revoke analytics cookie consent by calling the function setBannerCookieConsent:
->```js
+>
+> ```js
 > window.DI.analyticsGa4.cookie.setBannerCookieConsent(
->  false,
->  youranalyticsdomain,
->);
->```
+>   false,
+>   youranalyticsdomain,
+> );
+> ```
 
 # Trackers
 

--- a/src/analytics/formTracker/formTracker.test.ts
+++ b/src/analytics/formTracker/formTracker.test.ts
@@ -122,9 +122,13 @@ describe("FormTracker", () => {
     const result = instance.isExcludedType(element);
     expect(result).toBe(true);
   });
-
   test("isExcludedType should return true for submit input type", () => {
     const element: HTMLInputElement = { type: "submit" } as HTMLInputElement;
+    const result = instance.isExcludedType(element);
+    expect(result).toBe(true);
+  });
+  test("isExcludedType should return true for button type", () => {
+    const element: HTMLInputElement = { type: "button" } as HTMLInputElement;
     const result = instance.isExcludedType(element);
     expect(result).toBe(true);
   });

--- a/src/analytics/formTracker/formTracker.ts
+++ b/src/analytics/formTracker/formTracker.ts
@@ -16,6 +16,7 @@ export class FormTracker extends BaseTracker {
     return (
       element.type === "hidden" ||
       element.type === "fieldset" ||
+      element.type === "button" ||
       element.type === "submit"
     );
   }


### PR DESCRIPTION
…t have valid values

### Description

This removes non-submit buttons from the form elements list (submit buttons were already excluded). This is because they don't have a valid value, so they currently make all form responses invalid. This was found in the Auth repo where there is a hide/show button in the password entry form.

### Tickets

[DFC-642](https://govukverify.atlassian.net/browse/DFC-642)

### Steps to Reproduce

### Co-Authored By

### Checklist

[ ] - Are the commit messages for this PR in line with the GDS way?
[ ] - Have the changes in this PR been tested locally (if required)
[ ] - Have additional tests been added where required?
[ ] - Does the feature pass accessibility checks? (UI Components only)

### Additional Information


[DFC-642]: https://govukverify.atlassian.net/browse/DFC-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ