### PR TITLE
[DFC-646] - Add Core specific header classes to enable navigation

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,16 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Install Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
-    - name: Intall dependencies
-      run: npm install
+      - name: Intall dependencies
+        run: npm install
 
-    - name: Run Prettier
-      run: npm run prettier
+      - name: Run Prettier
+        run: npm run prettier
+
+      - name: Run Eslint
+        run: npm run eslint

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -41,6 +41,17 @@ describe("navigationTracker", () => {
       expect(BaseTracker.pushToDataLayer).toBeCalled();
     });
   });
+  test("should push data into data layer if click on logo icon within core", () => {
+    const element = document.createElement("span");
+    element.className = "govuk-header__logotype-crown";
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(element);
+    element.dispatchEvent(action);
+    element.addEventListener("click", () => {
+      expect(BaseTracker.pushToDataLayer).toBeCalled();
+    });
+  });
   // test trackNavigation return false if tracker is deactivated
   test("trackNavigation return false if tracker is deactivated", () => {
     const instance = new NavigationTracker(false);

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -40,6 +40,8 @@ export class NavigationTracker extends BaseTracker {
     let element: HTMLLinkElement = event.target as HTMLLinkElement;
     element = NavigationTracker.getParentElementIfSpecificClass(element, [
       "govuk-header__logotype",
+      "govuk-header__logotype-crown",
+      "one-login-header__logotype",
     ]);
 
     /*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,15 @@
 {
-    "compilerOptions": {
-      "outDir": "./dist/lib/",
-      "sourceMap": true,
-      "strict": true,
-      "noImplicitReturns": true,
-      "noImplicitAny": true,
-      "module": "es6",
-      "moduleResolution": "node",
-      "downlevelIteration": true,
-      "target": "es2016",
-      "allowJs": true
-    },
-    "include": [
-        "./src/**/*"
-    ]
+  "compilerOptions": {
+    "outDir": "./dist/lib/",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "module": "es6",
+    "moduleResolution": "node",
+    "downlevelIteration": true,
+    "target": "ES5",
+    "allowJs": true
+  },
+  "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "module": "es6",
       "moduleResolution": "node",
       "downlevelIteration": true,
-      "target": "es5",
+      "target": "es2016",
       "allowJs": true
     },
     "include": [


### PR DESCRIPTION
### Description

`ipv-core-front` uses a unique Header component with different classes than the generic GOVUK component. As a result, the navigation tracker does not fire in this case so the array of hooks has been extended to accommodate this.

### Tickets

[DFC-646](https://govukverify.atlassian.net/browse/DFC-646)

### Steps to Reproduce

### Checklist

[x] - Are the commit messages for this PR in line with the GDS way?
[x] - Have the changes in this PR been tested locally (if required)
[x] - Have additional tests been added where required?

### Additional Information


[DFC-646]: https://govukverify.atlassian.net/browse/DFC-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ