### PR TITLE
DFC-643 - Modify isExternal Check to cover all environments

### DIFF
--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -233,6 +233,11 @@ describe("isExternalLink", () => {
     expect(NavigationTracker.isExternalLink(url)).toBe(false);
   });
 
+  test("should return false for signin account links in staging", () => {
+    const url = "http://signin.staging.account.gov.uk/cookies";
+    expect(newInstance.isExternalLink(url)).toBe(false);
+  });
+
   test("should return true for external links", () => {
     const url = "https://google.com";
     expect(NavigationTracker.isExternalLink(url)).toBe(true);

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -235,7 +235,7 @@ describe("isExternalLink", () => {
 
   test("should return false for signin account links in staging", () => {
     const url = "http://signin.staging.account.gov.uk/cookies";
-    expect(newInstance.isExternalLink(url)).toBe(false);
+    expect(NavigationTracker.isExternalLink(url)).toBe(false);
   });
 
   test("should return true for external links", () => {

--- a/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -224,7 +224,7 @@ describe("isExternalLink", () => {
   new NavigationTracker(true);
 
   test("should return false for internal links", () => {
-    const url = "http://localhost";
+    const url = "http://account.gov.uk";
     expect(NavigationTracker.isExternalLink(url)).toBe(false);
   });
 

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -157,13 +157,15 @@ export class NavigationTracker extends BaseTracker {
    */
   static isExternalLink(url: string): boolean {
     const signinAccountUkUrl = "signin.account.gov.uk";
+    const signinAccountUkUrlStaging = "signin.staging.account.gov.uk";
     if (!url) {
       return false;
     }
 
     if (
       url.includes(window.location.hostname) ||
-      url.includes(signinAccountUkUrl)
+      url.includes(signinAccountUkUrl) ||
+      url.includes(signinAccountUkUrlStaging)
     ) {
       return false;
     }

--- a/src/analytics/navigationTracker/navigationTracker.ts
+++ b/src/analytics/navigationTracker/navigationTracker.ts
@@ -156,20 +156,11 @@ export class NavigationTracker extends BaseTracker {
    * @return {boolean} Returns true if the URL is an external link, false otherwise.
    */
   static isExternalLink(url: string): boolean {
-    const signinAccountUkUrl = "signin.account.gov.uk";
-    const signinAccountUkUrlStaging = "signin.staging.account.gov.uk";
     if (!url) {
       return false;
     }
 
-    if (
-      url.includes(window.location.hostname) ||
-      url.includes(signinAccountUkUrl) ||
-      url.includes(signinAccountUkUrlStaging)
-    ) {
-      return false;
-    }
-    return true;
+    return !url.includes("account.gov.uk");
   }
 
   /**


### PR DESCRIPTION
### Description

Modifies the `isExternal` check to assert whether or not `account.gov.uk` is present in the URL.

### Tickets

[DFC-643](https://govukverify.atlassian.net/browse/DFC-643)

### Checklist

[x] - Are the commit messages for this PR in line with the GDS way?
[x] - Have additional tests been added where required?

### Additional Information


[DFC-643]: https://govukverify.atlassian.net/browse/DFC-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ