### PR TITLE
[DFC-670] - Add CODEOWNERS File

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @govuk-one-login/digital-identity-frontend-capability # Team ownership with break-glass overrides


### PR DESCRIPTION
### Description

This adds a CODEOWNERS file marking the team `@govuk-one-login/digital-identity-frontend-capability` as codeowners for this repository

### Tickets

[DFC-670](https://govukverify.atlassian.net/browse/DFC-670)

[DFC-670]: https://govukverify.atlassian.net/browse/DFC-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ