### PR TITLE
Chore: Remove files config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "type": "git",
     "url": "git+https://github.com/govuk-one-login/di-fec-ga4.git"
   },
-  "files": [
-    "lib"
-  ],
   "keywords": [
     "govuk-one-login",
     "gds",


### PR DESCRIPTION
### Description
Minor configuration update to remove the `files` array from `package.json`. This option limited the files that would be picked up by `npm publish`, preventing the `componentsd/ga4-opl` folder from being included.

### Steps to Reproduce
The command `npm run pub --dry-run true` will output in the terminal the structure of the release. With `"files": ["lib/"]` included, only `lib/`, `package.json` and `README.md` are included in the release

With
<img width="948" alt="image" src="https://github.com/user-attachments/assets/d45ceea0-04b7-4965-9ff9-eb03685a5473">

Without
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ac16201e-b41a-4397-83ba-434ddca541a8">

